### PR TITLE
EXPIRE now accepts values over 2**31-1 msec

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ Currently implemented are the following redis commands:
 ### Strings
 * get
 * set
+* getset
 * mget
 * setex
 * setnx

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -43,7 +43,7 @@ exports.expire = function (mockInstance, key, seconds, callback) {
 
   if (obj) {
     var now = new Date().getTime();
-    var milli = (seconds*1000);
+    var milli = Math.min(seconds*1000, Math.pow(2, 31) - 1);
 
     if (mockInstance.storage[key]._expire) {
       clearTimeout(mockInstance.storage[key]._expire);

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -172,6 +172,11 @@ RedisClient.prototype.get = RedisClient.prototype.GET = function (key, callback)
   stringfunctions.get.call(this, MockInstance, key, callback);
 };
 
+RedisClient.prototype.getset = RedisClient.prototype.GETSET = function (key, value, callback) {
+
+  stringfunctions.getset.call(this, MockInstance, key, value, callback);
+};
+
 //SET key value [EX seconds] [PX milliseconds] [NX|XX]
 RedisClient.prototype.set = RedisClient.prototype.SET = function (key, value, callback) {
     var args = [];

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -50,6 +50,22 @@ exports.get = function (mockInstance, key, callback) {
   mockInstance._callCallback(callback, err, value);
 }
 
+/**
+ * Getset
+ */
+exports.getset = function (mockInstance, key, value, callback) {
+
+  exports.get(mockInstance, key, /*callback);,*/ function(err, oldValue) {
+    if (err) {
+      return mockInstance._callCallback(callback, err, null);
+    }
+  
+    mockInstance.storage[key] = Item.createString(value);
+
+    mockInstance._callCallback(callback, err, oldValue);
+  });
+};
+
 exports.mget = function (mockInstance) {
 
   var keys = [];

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -128,6 +128,23 @@ describe("expire", function () {
       });
     });
   });
+
+  it("accepts timeouts exceeding 2**31 msec", function (done) {
+    var r = redismock.createClient();
+    r.set("test_exceeds", "val", function (err, result) {
+      r.expire("test_exceeds", 86400*31 /* one month */, function (err, result) {
+        result.should.equal(1);
+        setTimeout(function () {
+          r.exists("test_exceeds", function (err, result) {
+            result.should.equal(1);
+            r.end();
+            done();
+          });
+        }, 1000);
+      });
+    });
+  });
+
 });
 
 describe("ttl", function () {

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -164,6 +164,50 @@ describe("get", function () {
   });
 });
 
+describe("getset", function () {
+  var r;
+
+  beforeEach(function () {
+    r = redismock.createClient();
+  });
+
+  it("should return null for a non-existing key", function (done) {
+    r.getset("does-not-exist", "newValue", function (err, result) {
+      should.not.exist(result);
+
+      r.end();
+      done();
+    });
+
+  });
+
+  it("should return the value of the key before setting it", function (done) {
+    r.set("test-key", "oldValue", function (err, result) {
+      r.getset("test-key", "newValue", function (err, result) {
+        result.should.equal("oldValue");
+        r.get("test-key", function (err, result) {
+          result.should.equal("newValue");
+          r.end();
+          done();
+        });
+      });
+    });
+  });
+
+  it("should return an error if the key holds the wrong type of value", function (done) {
+    r.sadd("test-key", "setMember", function (err, result) {
+      result.should.equal(1);
+      r.getset("test-key", "newValue", function (err, result) {
+        err.message.should.eql("WRONGTYPE Operation against a key holding the wrong kind of value");
+
+        r.end();
+        done();
+      });
+    });
+  });
+
+});
+
 describe("setex", function () {
 
   var r;


### PR DESCRIPTION
This patch enables the EXPIRE command to accept timeouts greater than (2**31)-1 msec, which is a limitation of JavaScript's setTimeout command, but not a limitation of Redis.