### PR TITLE
Added support for psubscribe and punsubscribe

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,0 +1,25 @@
+var charMap = {
+  '?': '.',
+  '\\?': '\\?',
+  '*': '.*',
+  '\\*': '\\*',
+  '^': '\\^',
+  '[^': '[^',
+  '\\[^': '\\[\\^',
+  '$': '\\$',
+  '+': '\\+',
+  '.': '\\.',
+  '(': '\\(',
+  ')': '\\)',
+  '{': '\\{',
+  '}': '\\}',
+  '|': '\\|'
+};
+
+var patternChanger = /\\\?|\?|\\\*|\*|\\\[\^|\[\^|\^|\$|\+|\.|\(|\)|\{|\}|\|/g;
+
+/* Converting pattern into regex */
+exports.patternToRegex = function(pattern) {
+  var fixed = pattern.replace(patternChanger, matched => charMap[matched]);
+  return new RegExp('^' + fixed + '$');
+}

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -20,6 +20,6 @@ var patternChanger = /\\\?|\?|\\\*|\*|\\\[\^|\[\^|\^|\$|\+|\.|\(|\)|\{|\}|\|/g;
 
 /* Converting pattern into regex */
 exports.patternToRegex = function(pattern) {
-  var fixed = pattern.replace(patternChanger, matched => charMap[matched]);
+  var fixed = pattern.replace(patternChanger, function(matched) { return charMap[matched] });
   return new RegExp('^' + fixed + '$');
 }

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -1,4 +1,6 @@
-﻿/**
+﻿var patternToRegex = require('./helpers').patternToRegex;
+
+/**
  * Del
  */
 exports.del = function (mockInstance, keys, callback) {
@@ -86,47 +88,6 @@ exports.ttl = function (mockInstance, key, callback) {
 
   mockInstance._callCallback(callback, null, result);
 };
-
-/* Converting pattern into regex */
-function patternToRegex(pattern) {
-
-  function process_plain(start, length) {
-    var plain = pattern.substr(start, length);
-    plain = plain.replace(/(\(|\)|\\|\.|\^|\$|\||\+)/gi
-      , function (spec) {
-        return '\\' + spec
-      });
-    plain = plain.replace('*', '.*');
-    plain = plain.replace('?', '.');
-    return plain;
-  }
-
-  var current_position = 0;
-  var parts = [];
-  var group_regex = /\[([^\]]+?)\]/ig;
-
-  var matches;
-  while (matches = group_regex.exec(pattern)) {
-    if (matches.index > 0) {
-      parts.push(process_plain(current_position, matches.index - current_position));
-    }
-    var groups = matches[1].split('');
-    for (var i in groups) {
-      groups[i] = groups[i].replace(/(\(|\)|\\|\.|\^|\$|\||\?|\+|\*)/gi
-        , function (spec) {
-          return '\\' + spec
-        });
-    }
-
-    var group = '(' + groups.join('|') + ')'
-    parts.push(group);
-    current_position = matches.index + matches[0].length;
-  }
-  if (current_position != pattern.length) {
-    parts.push(process_plain(current_position, pattern.length - current_position));
-  }
-  return new RegExp(parts.join(''));
-}
 
 /**
  * Keys

--- a/lib/pubsub.js
+++ b/lib/pubsub.js
@@ -5,6 +5,9 @@
  *   Optional callback?
  *
  */
+
+var patternToRegex = require('./helpers').patternToRegex;
+
 exports.subscribe = function () {
 
   var self = this;
@@ -30,6 +33,25 @@ exports.subscribe = function () {
   }
 }
 
+/**
+ * pSubscribe
+ */
+exports.psubscribe = function () {
+  var self = this;
+  if (!arguments.length) { return; }
+  this.pub_sub_mode = true;
+
+  for (var i = 0; i < arguments.length; i++) {
+    if ('string' == typeof arguments[i]) {
+      // Event on next tick to emulate an actual server call
+      var channelName = arguments[i];
+      process.nextTick(function () {
+        self.psubscriptions[channelName] = patternToRegex(channelName);
+        self.emit('psubscribe', channelName);
+      });
+    }
+  }
+}
 /**
  * Unsubscribe
  */
@@ -61,6 +83,32 @@ exports.unsubscribe = function () {
 
   // TODO: If this was the last subscription, pub_sub_mode should be set to false
   this.pub_sub_mode = false;
+}
+
+/**
+ * punsubscribe
+ */
+exports.punsubscribe = function () {
+  var self = this
+    , subcriptions = arguments;
+
+  // Unsubscribe from ALL channels
+  if (!arguments.length) {
+    subcriptions = Object.keys(self.psubscriptions);
+    this.pub_sub_mode = false;
+  }
+
+  for (var i = 0; i < subcriptions.length; i++) {
+    if ('string' == typeof arguments[i]) {
+      // Event on next tick to emulate an actual server call
+      var channelName = arguments[i];
+      process.nextTick(function () {
+        delete self.psubscriptions[channelName];
+        self.emit('punsubscribe', channelName);
+      });
+    }
+  }
+  // TODO: If this was the last subscription, pub_sub_mode should be set to false
 }
 
 /**

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -55,7 +55,7 @@ function RedisClient(stream, options) {
       self.emit('message', ch, msg);
     }
 
-    Object.keys(self.psubscriptions).some(key => {
+    Object.keys(self.psubscriptions).some(function(key) {
       if(self.psubscriptions[key].test(ch)) {
         self.emit('pmessage', ch, msg);
         return true;

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -57,7 +57,7 @@ function RedisClient(stream, options) {
 
     Object.keys(self.psubscriptions).some(function(key) {
       if(self.psubscriptions[key].test(ch)) {
-        self.emit('pmessage', ch, msg);
+        self.emit('pmessage', key, msg);
         return true;
       }
       return false;

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -54,12 +54,21 @@ function RedisClient(stream, options) {
     if (ch in self.subscriptions && self.subscriptions[ch] == true) {
       self.emit('message', ch, msg);
     }
+
+    Object.keys(self.psubscriptions).some(key => {
+      if(self.psubscriptions[key].test(ch)) {
+        self.emit('pmessage', ch, msg);
+        return true;
+      }
+      return false;
+    });
   }
 
   MockInstance.on('message', this._message);
 
   // Pub/sub subscriptions
-  this.subscriptions = [];
+  this.subscriptions = {};
+  this.psubscriptions = {};
 
   process.nextTick(function () {
 
@@ -111,7 +120,9 @@ RedisClient.prototype.quit = end;
  */
 var pubsub = require("./pubsub.js");
 RedisClient.prototype.subscribe = pubsub.subscribe;
+RedisClient.prototype.psubscribe = pubsub.psubscribe;
 RedisClient.prototype.unsubscribe = pubsub.unsubscribe;
+RedisClient.prototype.punsubscribe = pubsub.punsubscribe;
 RedisClient.prototype.publish = function (channel, msg) {
   pubsub.publish.call(this, MockInstance, channel, msg);
 }

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "yeahoffline (Frank) <frank.gasser@gmail.com>",
     "cmawhorter (cory) <cory.mawhorter@gmail.com>",
     "pmarques (Patrick Marques) <>"
+    "matthewmatician (Matthew Larson) <matthewmatician@gmail.com>",
   ],
   "bugs": {
     "url" : "https://github.com/yeahoffline/redis-mock/issues",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "lahabana (Charly Molter) <charly.molter@gmail.com>",
     "yeahoffline (Frank) <frank.gasser@gmail.com>",
     "cmawhorter (cory) <cory.mawhorter@gmail.com>",
-    "pmarques (Patrick Marques) <>"
+    "pmarques (Patrick Marques) <>",
     "matthewmatician (Matthew Larson) <matthewmatician@gmail.com>",
   ],
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yeahoffline (Frank) <frank.gasser@gmail.com>",
     "cmawhorter (cory) <cory.mawhorter@gmail.com>",
     "pmarques (Patrick Marques) <>",
-    "matthewmatician (Matthew Larson) <matthewmatician@gmail.com>",
+    "matthewmatician (Matthew Larson) <matthewmatician@gmail.com>"
   ],
   "bugs": {
     "url" : "https://github.com/yeahoffline/redis-mock/issues",

--- a/test/redis-mock.helpers.test.js
+++ b/test/redis-mock.helpers.test.js
@@ -1,0 +1,56 @@
+﻿var helpers = require("../lib/helpers")
+var should = require("should")
+
+describe("patternToRegex", function () {
+  it("should make straightforward matches on simple strings", function () {
+    testPattern("hello", ["hello"], ["words", "hello."])
+    testPattern("hello.", ["hello."], ["hello..", "hellos"])
+    testPattern("hello :)", ["hello :)"], ["hellos", "hello:("])
+  })
+
+  it("should work with ? patterns", function () {
+    testPattern("h?llo", ["hello", "hallo", "h?llo"], ["words", "hello."])
+    testPattern("h\\?llo", ["h?llo"], ["hello", "hallo"])
+  })
+
+  it("should work with * patterns", function () {
+    testPattern("h*llo", ["hllo", "hello", "h???llo"], ["hall", "hello."])
+    testPattern("h\\*llo", ["h*llo"], ["hello", "hallo"])
+  })
+
+  it("should work with [] patterns", function () {
+    testPattern("h[ae]llo", ["hello", "hallo"], ["hullo", "h?llo"])
+    testPattern("h\\[\\]llo", ["h[]llo"], ["hello"])
+  })
+
+  it("should work with [^] patterns", function () {
+    testPattern("h[^ae]llo", ["hullo", "h?llo"], ["hallo", "hello"])
+  })
+
+  it("should work with weird [] patterns", function () {
+    var pattern = "h[\\^\\?\\*.(){}\\\\\\[\\]]llo"
+    var goodStrings = ["h^llo", "h?llo", "h*llo", "h.llo", "h(llo", "h)llo", "h{llo", "h}llo", "h\\llo", "h[llo", "h]llo"]
+    var badStrings = ["hallo", "hello", "hullo"]
+    testPattern(pattern, goodStrings, badStrings)
+  })
+
+  it("should work with weird [^] patterns", function () {
+    var pattern = "h[^\\^\\?\\*.(){}\\\\\\[\\]]llo"
+    var goodStrings = ["hallo", "hello", "hullo"]
+    var badStrings = ["h^llo", "h?llo", "h*llo", "h.llo", "h(llo", "h)llo", "h{llo", "h}llo", "h\\llo", "h[llo", "h]llo"]
+    testPattern(pattern, goodStrings, badStrings)
+  })
+
+})
+
+function testPattern(pattern, passes, fails) {
+  var regex = helpers.patternToRegex(pattern)
+  withPattern(regex, passes, true)
+  withPattern(regex, fails, false)
+}
+
+function withPattern(regex, strings, expected) {
+  strings.forEach(function (x) {
+    should.equal(regex.test(x), expected)
+  })
+}

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -35,12 +35,50 @@ describe("publish and subscribe", function () {
     r.subscribe(channelName);
   });
 
+  it("should psubscribe and punsubscribe to a channel", function (done) {
+    var r = redismock.createClient();
+    var channelName = "testchannel";
+
+    should.exist(r.psubscribe);
+    should.exist(r.punsubscribe);
+
+    r.on("psubscribe", function (ch) {
+      should.equal(ch, channelName);
+      r.punsubscribe("testchannel");
+    });
+
+    r.on("punsubscribe", function (ch) {
+      should.equal(ch, channelName);
+      r.end();
+      done();
+    });
+    r.psubscribe(channelName);
+  });
+
   it("suscribing and publishing with the same connection should make an error", function (done) {
     var channelName = "testchannel";
     var otherChannel = "otherchannel";
 
     var r = redismock.createClient();
     r.subscribe(channelName);
+
+    try {
+      (function () {
+        r.publish(otherChannel, "");
+      }).should.throwError();
+    } catch (e) {
+      r.end();
+
+      done();
+    }
+  });
+
+  it("psuscribing and publishing with the same connection should make an error", function (done) {
+    var channelName = "testchannel";
+    var otherChannel = "otherchannel";
+
+    var r = redismock.createClient();
+    r.psubscribe(channelName);
 
     try {
       (function () {
@@ -76,6 +114,29 @@ describe("publish and subscribe", function () {
     setTimeout(function () {
       r2.publish(channelName, "");
     }, 1000);
+  });
+
+  it("should only receive message on channels psubscribed to", function (done) {
+    var pattern = "h*llo\\*";
+    var goodChannels = ["hllo*", "hello*", "heello*"];
+    var badChannels = ["hllo", "hall", "hello*o"];
+    var index = 0;
+    var r = redismock.createClient();
+    var r2 = redismock.createClient();
+
+    r.psubscribe(pattern);
+    r.on('pmessage', function (ch, msg) {
+      ch.should.equal(goodChannels[index]);
+      index++;
+      if(index === goodChannels.length) {
+        r.punsubscribe(pattern);
+        r.end();
+        done();
+      }
+    });
+
+    badChannels.forEach(function (channelName) { r2.publish(channelName, ""); });
+    goodChannels.forEach(function (channelName) { r2.publish(channelName, ""); });
   });
 
   it("should support multiple subscribers", function (done) {
@@ -127,4 +188,47 @@ describe("publish and subscribe", function () {
     }, 500);
   });
 
+  it("should support multiple psubscribers", function (done) {
+
+    var channelName = "testchannel";
+    var doneChannel = "donechannel";
+
+    var r = redismock.createClient();
+    var r2 = redismock.createClient();
+    var r3 = redismock.createClient();
+
+    r.psubscribe(channelName);
+    r2.psubscribe(channelName);
+    r2.psubscribe(doneChannel);
+
+    var channelNameCallsRecieved = 0;
+
+    r.on('pmessage', function (ch, msg) {
+      ch.should.equal(channelName);
+      channelNameCallsRecieved++;
+    });
+
+    r2.on('pmessage', function (ch, msg) {
+      if (ch == channelName) {
+        channelNameCallsRecieved++;
+      } else if (ch == doneChannel) {
+        channelNameCallsRecieved.should.equal(4);
+        r.punsubscribe(channelName);
+        r2.punsubscribe(channelName);
+        r2.punsubscribe(doneChannel);
+
+        r.end();
+        r2.end();
+        done();
+      }
+    });
+    // Ensure the messages has got time to get to the server
+    setTimeout(function () {
+      r3.publish(channelName, "");
+      r3.publish(channelName, "");
+      setTimeout(function () {
+        r3.publish(doneChannel, "");
+      }, 100);
+    }, 100);
+  });
 });

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -126,7 +126,8 @@ describe("publish and subscribe", function () {
 
     r.psubscribe(pattern);
     r.on('pmessage', function (ch, msg) {
-      ch.should.equal(goodChannels[index]);
+      ch.should.equal(pattern);
+      msg.should.equal(goodChannels[index]);
       index++;
       if(index === goodChannels.length) {
         r.punsubscribe(pattern);
@@ -135,8 +136,8 @@ describe("publish and subscribe", function () {
       }
     });
 
-    badChannels.forEach(function (channelName) { r2.publish(channelName, ""); });
-    goodChannels.forEach(function (channelName) { r2.publish(channelName, ""); });
+    badChannels.forEach(function (channelName) { r2.publish(channelName, channelName); });
+    goodChannels.forEach(function (channelName) { r2.publish(channelName, channelName); });
   });
 
   it("should support multiple subscribers", function (done) {


### PR DESCRIPTION
In order to leverage pattern matching in `keys`, I moved the function `patternToRegex` out to a separate helpers.js file, so I could also use it in pubsub.js. I have added a lot of tests around `patternToRegex` to make sure it behaves well in many cases. Haven't yet filtered away functionality for special characters regex, like `\w`, which shouldn't match anything special in Redis.

Added psubscribe and punsubscribe functionality to match http://redis.io/commands/PSUBSCRIBE.