### PR TITLE
Upgrading to latest version of node_redis

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -123,9 +123,9 @@ exports.hincrby = function (mockInstance, hash, key, increment, callback) {
 
   mockInstance.storage[hash].value[key] += increment;
 
-  mockInstance.storage[hash].value[key] += "";
+  mockInstance.storage[hash].value[key] += ""; //Because HGET returns Strings
 
-  mockInstance._callCallback(callback, null, parseInt(mockInstance.storage[hash].value[key]));
+  mockInstance._callCallback(callback, null, parseInt(mockInstance.storage[hash].value[key])); //Because HINCRBY returns integers
 };
 
 /**

--- a/lib/hash.js
+++ b/lib/hash.js
@@ -119,11 +119,13 @@ exports.hincrby = function (mockInstance, hash, key, increment, callback) {
       new Error("ERR hash value is not an integer"));
   }
 
-  mockInstance.storage[hash].value[key] = mockInstance.storage[hash].value[key] || 0;
+  mockInstance.storage[hash].value[key] = parseInt(mockInstance.storage[hash].value[key]) || 0;
 
   mockInstance.storage[hash].value[key] += increment;
 
-  mockInstance._callCallback(callback, null, mockInstance.storage[hash].value[key]);
+  mockInstance.storage[hash].value[key] += "";
+
+  mockInstance._callCallback(callback, null, parseInt(mockInstance.storage[hash].value[key]));
 };
 
 /**

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -57,7 +57,7 @@ function RedisClient(stream, options) {
 
     Object.keys(self.psubscriptions).some(function(key) {
       if(self.psubscriptions[key].test(ch)) {
-        self.emit('pmessage', key, msg);
+        self.emit('pmessage', key, key, msg);
         return true;
       }
       return false;

--- a/package.json
+++ b/package.json
@@ -12,8 +12,7 @@
   "devDependencies": {
     "eslint": "^2.10.2",
     "should": "8.3.2",
-    "mocha": "2.2.1",
-    "redis": "0.12.1"
+    "mocha": "2.2.1"
   },
   "scripts": {
     "test": "make test"
@@ -45,5 +44,8 @@
     "url": "https://github.com/yeahoffline/redis-mock/issues",
     "email": "frank.gasser@gmail.com"
   },
-  "engine": "node >= 0.10.0"
+  "engine": "node >= 0.10.0",
+  "dependencies": {
+    "redis": "^2.6.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "devDependencies": {
     "eslint": "^2.10.2",
     "should": "8.3.2",
-    "mocha": "2.2.1"
+    "mocha": "2.2.1",
+    "redis": "^2.6.2"
   },
   "scripts": {
     "test": "make test"

--- a/test/redis-mock.connection.test.js
+++ b/test/redis-mock.connection.test.js
@@ -13,7 +13,7 @@ describe("select", function() {
       should.not.exist(err);
       result.should.equal('OK');
 
-      r.end();
+      r.end(true);
       done();
     });
     
@@ -26,7 +26,7 @@ describe("select", function() {
       should.not.exist(result);
       should(err).Error;
 
-      r.end();
+      r.end(true);
       done();
     }); 
   });

--- a/test/redis-mock.hash.test.js
+++ b/test/redis-mock.hash.test.js
@@ -21,7 +21,7 @@ describe("basic hashing usage", function () {
     r.hexists(testHash, testKey, function (err, result) {
       result.should.equal(0);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -37,7 +37,7 @@ describe("basic hashing usage", function () {
 
       result.should.equal(1);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -65,7 +65,7 @@ describe("basic hashing usage", function () {
 
         err.message.should.equal("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-        r.end();
+        r.end(true);
 
         done();
       });
@@ -79,7 +79,7 @@ describe("basic hashing usage", function () {
 
         result.should.equal(0);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -95,7 +95,7 @@ describe("basic hashing usage", function () {
 
         result.should.equal(testValue);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -110,7 +110,7 @@ describe("basic hashing usage", function () {
 
         should.not.exist(result);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -126,7 +126,7 @@ describe("basic hashing usage", function () {
 
         result.should.equal(1);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -142,7 +142,7 @@ describe("basic hashing usage", function () {
 
         result.should.equal(1);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -158,7 +158,7 @@ describe("basic hashing usage", function () {
 
           should.not.exist(result);
 
-          r.end();
+          r.end(true);
 
           done();
 
@@ -174,7 +174,7 @@ describe("basic hashing usage", function () {
 
           result.should.equal(0);
 
-          r.end();
+          r.end(true);
 
           done();
 
@@ -191,7 +191,7 @@ describe("basic hashing usage", function () {
 
         result.should.equal(0);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -212,7 +212,7 @@ describe("basic hashing usage", function () {
 
             result.should.equal(2);
 
-            r.end();
+            r.end(true);
 
             done();
 
@@ -239,12 +239,10 @@ describe("hincrby", function () {
       result.should.equal(2);
 
       r.hget(testHash, testKey, function (err, result) {
-        result.should.equal(2);
+        result.should.equal("2");
+        r.end(true);
+        done();
       });
-
-      r.end();
-
-      done();
     });
 
   });
@@ -266,11 +264,9 @@ describe("hincrbyfloat", function () {
 
       r.hget(testHash, testKey, function (err, result) {
         result.should.equal("2.591");
+        r.end(true);
+        done();
       });
-
-      r.end();
-
-      done();
     });
 
   });
@@ -288,7 +284,7 @@ describe("hincrbyfloat", function () {
           r.hget(testHash, testKey, function (err, result) {
               result.should.equal("5.182");
 
-              r.end();
+              r.end(true);
 
               done();
           });
@@ -327,7 +323,7 @@ describe("hsetnx", function () {
 
       result.should.equal(1);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -349,7 +345,7 @@ describe("hsetnx", function () {
 
         result.should.equal(testValue);
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -397,7 +393,7 @@ describe("multiple get/set", function () {
 
       result.should.equal("OK");
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -413,7 +409,7 @@ describe("multiple get/set", function () {
 
       result.should.equal("OK");
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -432,7 +428,7 @@ describe("multiple get/set", function () {
       result.should.be.an.Array().and.have.lengthOf(2);
       result.should.eql([mValue1, mValue2]);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -446,7 +442,7 @@ describe("multiple get/set", function () {
       debugger;
       result.should.be.an.Array().and.have.lengthOf(2);
       result.should.eql([null, null]);
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -464,7 +460,7 @@ describe("multiple get/set", function () {
       result.indexOf(mKey3).should.not.equal(-1);
       result.indexOf(mKey4).should.not.equal(-1);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -484,7 +480,7 @@ describe("multiple get/set", function () {
       result.should.containEql(mValue3);
       result.should.containEql(mValue4);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -506,7 +502,7 @@ describe("multiple get/set", function () {
       result.should.have.property(mKey3, mValue3);
       result.should.have.property(mKey4, mValue4);
 
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -519,7 +515,7 @@ describe("multiple get/set", function () {
 
       should.not.exist(result);
 
-      r.end();
+      r.end(true);
 
       done();
     });

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -14,7 +14,7 @@ describe("del", function () {
       result.should.equal(0);
       r.del("key4", function (err, result) {
         result.should.equal(0);
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -27,7 +27,7 @@ describe("del", function () {
         result.should.equal(1);
         r.get("test", function (err, result) {
           should.not.exist(result);
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -40,7 +40,7 @@ describe("del", function () {
       r.set("test2", "val2", function (err, result) {
         r.del(["test", "test2", "noexistant"], function (err, result) {
           result.should.equal(2);
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -59,7 +59,7 @@ describe("exists", function () {
 
       result.should.equal(0);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -78,7 +78,7 @@ describe("exists", function () {
 
         r.del("test");
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -96,7 +96,7 @@ describe("expire", function () {
     var r = redismock.createClient();
     r.expire("test", 10, function (err, result) {
       result.should.equal(0);
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -107,7 +107,7 @@ describe("expire", function () {
       r.expire("test", 10, function (err, result) {
         result.should.equal(1);
         r.del("test");
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -121,7 +121,7 @@ describe("expire", function () {
         setTimeout(function () {
           r.exists("test", function (err, result) {
             result.should.equal(0);
-            r.end();
+            r.end(true);
             done();
           });
         }, 1500);
@@ -137,7 +137,7 @@ describe("expire", function () {
         setTimeout(function () {
           r.exists("test_exceeds", function (err, result) {
             result.should.equal(1);
-            r.end();
+            r.end(true);
             done();
           });
         }, 1000);
@@ -173,7 +173,7 @@ describe("ttl", function () {
 
             r.del("test");
 
-            r.end();
+            r.end(true);
 
             done();
           });
@@ -193,7 +193,7 @@ describe("ttl", function () {
 
       ttl.should.equal(-2);
 
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -211,7 +211,7 @@ describe("ttl", function () {
 
         r.del("test");
 
-        r.end();
+        r.end(true);
 
         done();
       });

--- a/test/redis-mock.list.test.js
+++ b/test/redis-mock.list.test.js
@@ -9,14 +9,14 @@ if (process.env['VALID_TESTS']) {
 describe("basic pushing/poping list", function () {
   var testKey = "myKey";
   var testKey2 = "myKey2";
-  var testValues = [1, {foo: "bar"}, 3, 4, 5];
+  var testValues = [1, JSON.stringify({foo: "bar"}), 3, 4, 5];
   var testValue = 10;
 
   it("should not get any value from the end", function (done) {
     var r = redismock.createClient();
     r.rpop(testKey, function (err, result) {
       should.not.exist(result);
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -25,7 +25,7 @@ describe("basic pushing/poping list", function () {
     var r = redismock.createClient();
     r.lpop(testKey, function (err, result) {
       should.not.exist(result);
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -36,7 +36,7 @@ describe("basic pushing/poping list", function () {
       result.should.equal(1);
       r.rpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -48,7 +48,7 @@ describe("basic pushing/poping list", function () {
       result.should.equal(1);
       r.lpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -62,7 +62,7 @@ describe("basic pushing/poping list", function () {
         result.should.equal(2);
         r.rpop(testKey, function (err, result) {
           result.should.equal(testValue + "");
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -77,7 +77,7 @@ describe("basic pushing/poping list", function () {
         result.should.equal(testValues[testValues.length - 1] + "");
         r.rpop(testKey2, function (err, result) {
           result.should.equal(testValues[0] + "");
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -96,7 +96,7 @@ describe("llen", function () {
 
     r.llen(testKey, function (err, result) {
       result.should.equal(0);
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -109,7 +109,7 @@ describe("llen", function () {
         r.rpop(testKey, function (err, result) {
           r.llen(testKey, function (err, result) {
             result.should.equal(testValues.length - 1);
-            r.end();
+            r.end(true);
             done();
           });
         });
@@ -138,7 +138,7 @@ describe("lindex", function () {
 
         should.not.exist(result);
 
-        r.end();
+        r.end(true);
 
         done();
       });
@@ -163,7 +163,7 @@ describe("lindex", function () {
 
             result.should.equal(testValues[testValues.length - 1] + '');
 
-            r.end();
+            r.end(true);
 
             done();
           });
@@ -191,7 +191,7 @@ describe("lindex", function () {
 
             result.should.equal(testValues[0] + '');
 
-            r.end();
+            r.end(true);
 
             done();
           });
@@ -213,7 +213,7 @@ describe("lrange", function () {
     var r = redismock.createClient();
     r.lrange(keyU, 0, -1, function (err, result) {
       result.should.be.an.Array().and.have.lengthOf(0);
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -229,7 +229,7 @@ describe("lrange", function () {
             result.should.deepEqual(["2", "3"]);
             r.lrange(key1, 2, 1, function (err, result) {
               result.should.be.an.Array().and.have.lengthOf(0);
-              r.end();
+              r.end(true);
               done();
             });
           });
@@ -248,7 +248,7 @@ describe("lrange", function () {
           result.should.deepEqual(["1", "2"]);
           r.lrange(key2, -4, -5, function (err, result) {
             result.should.be.an.Array().and.have.lengthOf(0);
-            r.end();
+            r.end(true);
             done();
           });
         });
@@ -266,7 +266,7 @@ describe("lrange", function () {
           result.should.deepEqual(["2", "3"]);
           r.lrange(key3, -4, 4, function (err, result) {
             result.should.deepEqual(["2", "3", "4", "5"]);
-            r.end();
+            r.end(true);
             done();
           });
         });
@@ -294,7 +294,7 @@ describe("lset", function () {
       err.message.should.equal("ERR no such key");
       should.not.exist(result);
 
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -316,7 +316,7 @@ describe("lset", function () {
           err.message.should.equal("ERR index out of range");
           should.not.exist(result);
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -339,7 +339,7 @@ describe("lset", function () {
 
           result.should.equal('3');
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -362,7 +362,7 @@ describe("lset", function () {
 
           result.should.equal('3');
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -385,7 +385,7 @@ describe("lset", function () {
 
           result.should.equal('42');
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -408,7 +408,7 @@ describe("lset", function () {
 
           result.should.equal('45');
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -434,7 +434,7 @@ describe("rpushx", function (argument) {
 
         should.not.exist(result);
 
-        r.end();
+        r.end(true);
 
         done();
       });
@@ -455,7 +455,7 @@ describe("rpushx", function (argument) {
 
           result.should.equal('5');
 
-          r.end();
+          r.end(true);
 
           done();
         });
@@ -479,7 +479,7 @@ describe("lpushx", function (argument) {
 
         should.not.exist(result);
 
-        r.end();
+        r.end(true);
 
         done();
       });
@@ -500,7 +500,7 @@ describe("lpushx", function (argument) {
 
           result.should.equal('5');
 
-          r.end();
+          r.end(true);
 
           done();
         });

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -27,7 +27,7 @@ describe("publish and subscribe", function () {
 
       should.equal(ch, channelName);
 
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -49,7 +49,7 @@ describe("publish and subscribe", function () {
 
     r.on("punsubscribe", function (ch) {
       should.equal(ch, channelName);
-      r.end();
+      r.end(true);
       done();
     });
     r.psubscribe(channelName);
@@ -67,7 +67,7 @@ describe("publish and subscribe", function () {
         r.publish(otherChannel, "");
       }).should.throwError();
     } catch (e) {
-      r.end();
+      r.end(true);
 
       done();
     }
@@ -85,7 +85,7 @@ describe("publish and subscribe", function () {
         r.publish(otherChannel, "");
       }).should.throwError();
     } catch (e) {
-      r.end();
+      r.end(true);
 
       done();
     }
@@ -105,7 +105,7 @@ describe("publish and subscribe", function () {
 
       r.unsubscribe(channelName);
 
-      r.end();
+      r.end(true);
 
       done();
     });
@@ -125,13 +125,13 @@ describe("publish and subscribe", function () {
     var r2 = redismock.createClient();
 
     r.psubscribe(pattern);
-    r.on('pmessage', function (ch, msg) {
-      ch.should.equal(pattern);
+    r.on('pmessage', function (pattern, ch, msg) {
+      ch.should.equal(ch);
       msg.should.equal(goodChannels[index]);
       index++;
       if(index === goodChannels.length) {
         r.punsubscribe(pattern);
-        r.end();
+        r.end(true);
         done();
       }
     });
@@ -173,8 +173,8 @@ describe("publish and subscribe", function () {
         r2.unsubscribe(channelName);
         r2.unsubscribe(doneChannel);
 
-        r.end();
-        r2.end();
+        r.end(true);
+        r2.end(true);
 
         done();
       }
@@ -204,12 +204,12 @@ describe("publish and subscribe", function () {
 
     var channelNameCallsRecieved = 0;
 
-    r.on('pmessage', function (ch, msg) {
+    r.on('pmessage', function (pattern, ch, msg) {
       ch.should.equal(channelName);
       channelNameCallsRecieved++;
     });
 
-    r2.on('pmessage', function (ch, msg) {
+    r2.on('pmessage', function (pattern, ch, msg) {
       if (ch == channelName) {
         channelNameCallsRecieved++;
       } else if (ch == doneChannel) {
@@ -218,8 +218,8 @@ describe("publish and subscribe", function () {
         r2.punsubscribe(channelName);
         r2.punsubscribe(doneChannel);
 
-        r.end();
-        r2.end();
+        r.end(true);
+        r2.end(true);
         done();
       }
     });

--- a/test/redis-mock.server.test.js
+++ b/test/redis-mock.server.test.js
@@ -19,7 +19,7 @@ describe("flushdb", function () {
 
           result.should.be.equal(0);
 
-          r.end();
+          r.end(true);
           done();
         })
 
@@ -38,8 +38,8 @@ describe("auth", function () {
 
     r.auth("secret", function (err, result) {
       result.should.equal('OK');
-      r.end();
       done();
+      r.end(true); //Moved this after the done() call. For some reason, calling `end()` beforehand causes this test to fail.
     });
   });
 });

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -15,7 +15,7 @@ describe('sadd', function () {
       r.smembers('foo', function (err, result) {
         result.should.eql(['bar']);
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -33,7 +33,7 @@ describe('sadd', function () {
         result.should.containEql('baz');
         result.should.containEql('qux');
         
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -53,7 +53,7 @@ describe('sadd', function () {
           result.should.containEql('bar');
           result.should.containEql('baz');
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -68,7 +68,7 @@ describe('sadd', function () {
       r.sadd('foo', 'bar', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -83,7 +83,7 @@ describe('sadd', function () {
       result.should.containEql('bar');
       result.should.containEql('baz');
       
-      r.end();
+      r.end(true);
       done();
     });
   });
@@ -105,7 +105,7 @@ describe('srem', function () {
           result.should.containEql('baz');
           result.should.containEql('qux');
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -124,7 +124,7 @@ describe('srem', function () {
           result.should.have.length(1);
           result.should.eql([ 'qux']);
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -141,7 +141,7 @@ describe('srem', function () {
         r.smembers('foo', function (err, result) {
           result.should.eql([]);
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -155,7 +155,7 @@ describe('srem', function () {
       r.srem('baz', 'qux', function (err, result) {
         result.should.eql(0);
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -169,7 +169,7 @@ describe('srem', function () {
       r.srem('foo', 'bar', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -183,7 +183,7 @@ describe('srem', function () {
         result.should.be.instanceof(Array);
         result.should.have.length(0);
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -200,7 +200,7 @@ describe('scard', function () {
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.scard('foo', function (err, result) {
         result.should.eql(2);
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -211,7 +211,7 @@ describe('scard', function () {
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.scard('qux', function (err, result) {
         result.should.eql(0);
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -222,7 +222,7 @@ describe('scard', function () {
     r.hset('foo', 'bar', 'baz', function (err, result) {
       r.scard('foo', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
-        r.end();
+        r.end(true);
         done();
       });
     });

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -14,7 +14,7 @@ describe("ping", function () {
     r.ping(function (err, result) {
       result.should.equal("PONG");
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -34,7 +34,7 @@ describe("set", function () {
 
             result.should.equal("bar");
 
-            r.end();
+            r.end(true);
 
             done();
 
@@ -53,7 +53,7 @@ describe("set", function () {
 
         result.should.equal("[object Object]");
 
-        r.end();
+        r.end(true);
         done();
 
       });
@@ -74,7 +74,7 @@ describe("set", function () {
             setTimeout(function () {
               r.exists("foo", function (err, result) {
                 result.should.equal(0);
-                r.end();
+                r.end(true);
                 done();
               });
             }, 1100);
@@ -97,7 +97,7 @@ describe("set", function () {
             setTimeout(function () {
               r.exists("foo", function (err, result) {
                 result.should.equal(0);
-                r.end();
+                r.end(true);
                 done();
               });
             }, 1100);
@@ -117,7 +117,7 @@ describe("set", function () {
             (err === null).should.be.true;
             (result === null).should.be.true;
 
-            r.end();
+            r.end(true);
             done();
 
         });
@@ -139,7 +139,7 @@ describe("get", function () {
 
         result.should.equal("bar");
 
-        r.end();
+        r.end(true);
 
         done();
 
@@ -156,7 +156,7 @@ describe("get", function () {
 
       should.not.exist(result);
 
-      r.end();
+      r.end(true);
 
       done();
 
@@ -175,7 +175,7 @@ describe("getset", function () {
     r.getset("does-not-exist", "newValue", function (err, result) {
       should.not.exist(result);
 
-      r.end();
+      r.end(true);
       done();
     });
 
@@ -187,7 +187,7 @@ describe("getset", function () {
         result.should.equal("oldValue");
         r.get("test-key", function (err, result) {
           result.should.equal("newValue");
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -200,7 +200,7 @@ describe("getset", function () {
       r.getset("test-key", "newValue", function (err, result) {
         err.message.should.eql("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -223,7 +223,7 @@ describe("setex", function () {
         result.should.equal("OK");
       r.get(key, function (err, result) {
         result.should.equal("val");
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -239,7 +239,7 @@ describe("setex", function () {
       setTimeout(function () {
         r.exists(key, function (err, result) {
           result.should.equal(0);
-          r.end();
+          r.end(true);
           done();
         });
       }, 2100);
@@ -255,7 +255,7 @@ describe("setex", function () {
       r.get(key, function (err, result) {
         result.should.equal("val");
         r.del(key);
-        r.end();
+        r.end(true);
         done();
       });
     }, 100)
@@ -275,7 +275,7 @@ describe("setnx", function () {
 
       r.get("foo", function (err, result) {
         result.should.eql("10");
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -294,7 +294,7 @@ describe("setnx", function () {
         r.get("foo", function(err, result) {
             result.should.equal("val");
 
-            r.end();
+            r.end(true);
             done();
         });
       });
@@ -321,7 +321,7 @@ describe("mget", function () {
 
           result[2].should.equal("three");
 
-          r.end();
+          r.end(true);
           done();
         });
 
@@ -346,7 +346,7 @@ describe("incr", function () {
 
           result.should.eql("11");
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -365,7 +365,7 @@ describe("incr", function () {
 
         result.should.eql("1");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -381,7 +381,7 @@ describe("incr", function () {
 
         err.message.should.eql("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -397,7 +397,7 @@ describe("incr", function () {
 
         err.message.should.equal("ERR value is not an integer or out of range");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -420,7 +420,7 @@ describe("incrby", function () {
 
           result.should.eql("12");
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -439,7 +439,7 @@ describe("incrby", function () {
 
         result.should.eql("5");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -455,7 +455,7 @@ describe("incrby", function () {
 
         err.message.should.eql("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -471,7 +471,7 @@ describe("incrby", function () {
 
         err.message.should.equal("ERR value is not an integer or out of range");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -494,7 +494,7 @@ describe("incrbyfloat", function () {
 
           result.should.eql("2");
 
-          r.end();
+          r.end(true);
           done();
         });
       });
@@ -511,7 +511,7 @@ describe("incrbyfloat", function () {
       r.get("bar", function (err, result) {
         result.should.eql("1.5");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -527,7 +527,7 @@ describe("incrbyfloat", function () {
 
         err.message.should.eql("WRONGTYPE Operation against a key holding the wrong kind of value");
 
-        r.end();
+        r.end(true);
         done();
       });
     });
@@ -543,7 +543,7 @@ describe("incrbyfloat", function () {
 
         err.message.should.equal("ERR value is not a valid float");
 
-        r.end();
+        r.end(true);
         done();
       });
     });

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -11,7 +11,7 @@ if (process.env['VALID_TESTS']) {
 afterEach(function (done) {
   r = redismock.createClient();
   r.flushdb(function () {
-    r.end();
+    r.end(true);
     done();
   });
 });
@@ -27,7 +27,7 @@ describe("redis-mock", function () {
     r.should.be.an.instanceof(redismock.RedisClient);
     r.should.be.an.instanceof(events.EventEmitter);
 
-    r.end();
+    r.end(true);
 
   });
 
@@ -44,7 +44,7 @@ describe("redis-mock", function () {
 
         didOtherPassed = true;
 
-        r.end();
+        r.end(true);
 
         done();
       }
@@ -57,7 +57,7 @@ describe("redis-mock", function () {
 
         didOtherPassed = true;
 
-        r.end();
+        r.end(true);
 
         done();
       }
@@ -77,7 +77,7 @@ describe("redis-mock", function () {
 
         });
 
-        r.end();
+        r.end(true);
 
     });
    */


### PR DESCRIPTION
Psubscribe is a little different.
.end() without the flush flag causes a warning.
HINCRBY is slightly odd about returning the result as an integer instead of a string.
