### PR TITLE
Refactor hmset argument parsing

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -225,49 +225,28 @@ exports.hvals = function (mockInstance, hash, callback) {
 /**
  * Hmset
  */
-exports.hmset = function (mockInstance) {
+exports.hmset = function (mockInstance, hash) {
 
   // We require at least 3 arguments
   // 0: mockInstance
   // 1: hash name
-  // 2: key/value object or first key name
-  if (arguments.length <= 3) {
+  // 2..N-2: key
+  // 3..N-1: value
+  // N: callback (optional)
+
+  var len = arguments.length;
+  if (len <= 3) {
     return;
   }
 
-  var keyValuesToAdd = {};
-
-  if ('object' == typeof arguments[2]) {
-
-    keyValuesToAdd = arguments[2];
-
-  } else {
-
-    for (var i = 2; i < arguments.length; i += 2) {
-
-      // Array big enough to have both a key and value
-      if (arguments.length > (i + 1)) {
-        var newKey = arguments[i];
-        var newValue = arguments[i + 1];
-
-        // Neither key nor value is a callback
-        if ('function' !== typeof newKey && 'function' !== typeof newValue) {
-
-          keyValuesToAdd[newKey] = newValue;
-
-        } else {
-          break;
-        }
-      } else {
-        break;
-      }
-    }
+  var callback;
+  if ('function' === typeof arguments[len - 1]) {
+    callback = arguments[len-1];
   }
 
-  var hash = arguments[1];
-
+  // check to see if this hash exists
   if (mockInstance.storage[hash]) {
-    if (mockInstance.storage[hash].type !== "hash") {
+    if (mockInstance.storage[hash].type !== "hash" && callback) {
       return mockInstance._callCallback(callback,
         new Error("ERR Operation against a key holding the wrong kind of value"));
     }
@@ -275,13 +254,19 @@ exports.hmset = function (mockInstance) {
     mockInstance.storage[hash] = new Item.createHash();
   }
 
-  for (var k in keyValuesToAdd) {
-    mockInstance.storage[hash].value[k] = keyValuesToAdd[k];
+  for (var i = 2; i < len; i += 2) {
+    if (len <= (i + 1)) {
+      // should skip the callback here
+      break;
+    }
+    var k = arguments[i];
+    var v = arguments[i + 1];
+    mockInstance.storage[hash].value[k] = v;
   }
 
   // Do we have a callback?
-  if ('function' === typeof arguments[arguments.length - 1]) {
-    mockInstance._callCallback(arguments[arguments.length - 1], null, "OK");
+  if (callback) {
+    mockInstance._callCallback(callback, null, "OK");
   }
 }
 

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -312,7 +312,6 @@ RedisClient.prototype.mget = RedisClient.prototype.MGET = function () {
   stringfunctions.mget.apply(this, newArguments);
 };
 
-
 /**
  * Hashing functions
  */
@@ -361,12 +360,61 @@ RedisClient.prototype.hvals = RedisClient.prototype.HVALS = function (hash, call
 }
 RedisClient.prototype.hmset = RedisClient.prototype.HMSET = function () {
 
-  var newArguments = [MockInstance];
-  for (var i = 0; i < arguments.length; i++) {
-    newArguments.push(arguments[i]);
+  // See node_redis client hmset arguments parsing:
+  // https://github.com/NodeRedis/node_redis/blob/master/lib/individualCommands.js#L316
+  var arr,
+      len = arguments.length,
+      callback,
+      i = 0;
+  if (Array.isArray(arguments[0])) {
+    // arg0 = [hash, k1, v1, k2, v2,]
+    // arg1 = callback
+    arr = arguments[0];
+    callback = arguments[1];
+  } else if (Array.isArray(arguments[1])) {
+    // arg0 = hash
+    // arg1 = [k1, v1, k2, v2,]
+    // arg2 = callback
+    if (len === 3) {
+      callback = arguments[2];
+    }
+    len = arguments[1].length;
+    arr = new Array(len + 1);
+    arr[0] = arguments[0];
+    for (; i < len; i += 1) {
+      arr[i + 1] = arguments[1][i];
+    }
+  } else if (typeof arguments[1] === 'object' &&
+    (arguments.length === 2 || arguments.length === 3 &&
+      (typeof arguments[2] === 'function' || typeof arguments[2] === 'undefined'))) {
+        // arg0 = hash
+        // arg1 = {k1: v1, k2: v2,}
+        // arg2 = callback
+        arr = [arguments[0]];
+        for (var field in arguments[1]) {
+            arr.push(field, arguments[1][field]);
+        }
+        callback = arguments[2];
+  } else {
+    // arg0 = hash
+    // arg1..N-1 = k1,v1,k2,v2,...N-1
+    // argN = callback
+    len = arguments.length;
+    // The later should not be the average use case
+    if (len !== 0 && (typeof arguments[len - 1] === 'function' || typeof arguments[len - 1] === 'undefined')) {
+      len--;
+      callback = arguments[len];
+    }
+    arr = new Array(len);
+    for (; i < len; i += 1) {
+      arr[i] = arguments[i];
+    }
+  }
+  if (callback) {
+    arr.push(callback);
   }
 
-  hashing.hmset.apply(this, newArguments);
+  hashing.hmset.apply(this, [MockInstance].concat(arr));
 }
 RedisClient.prototype.hmget = RedisClient.prototype.HMGET = function () {
 

--- a/test/redis-mock.hash.test.js
+++ b/test/redis-mock.hash.test.js
@@ -253,10 +253,11 @@ describe("hincrbyfloat", function () {
 
   var testHash = "myHashToIncrFloat";
   var testKey = "myKeyToIncrFloat";
+  var testKey2 = "myKeyToIncrFloat2";
+
 
   var num = 2.591;
   var x2 = num * 2;
-  var x3 = num * 3;
 
   it("should increment an attribute of the hash", function (done) {
 
@@ -278,14 +279,14 @@ describe("hincrbyfloat", function () {
 
     var r = redismock.createClient();
 
-    r.hincrbyfloat(testHash, testKey, num, function (err, result) {
-      result.should.equal(x2.toString());
+    r.hincrbyfloat(testHash, testKey2, num, function (err, result) {
+      result.should.equal(num.toString());
 
-      r.hincrbyfloat(testHash, testKey, num, function (err, result) {
-          result.should.equal(x3.toString());
+      r.hincrbyfloat(testHash, testKey2, num, function (err, result) {
+          result.should.equal(x2.toString());
 
-          r.hget(testHash, testKey, function (err, result) {
-              result.should.equal(x3.toString());
+          r.hget(testHash, testKey2, function (err, result) {
+              result.should.equal(x2.toString());
 
               r.end(true);
 

--- a/test/redis-mock.hash.test.js
+++ b/test/redis-mock.hash.test.js
@@ -254,16 +254,19 @@ describe("hincrbyfloat", function () {
   var testHash = "myHashToIncrFloat";
   var testKey = "myKeyToIncrFloat";
 
+  var num = 2.591;
+  var x2 = num * 2;
+  var x3 = num * 3;
 
   it("should increment an attribute of the hash", function (done) {
 
     var r = redismock.createClient();
 
-    r.hincrbyfloat(testHash, testKey, 2.591, function (err, result) {
-      result.should.equal("2.591");
+    r.hincrbyfloat(testHash, testKey, num, function (err, result) {
+      result.should.equal(num.toString());
 
       r.hget(testHash, testKey, function (err, result) {
-        result.should.equal("2.591");
+        result.should.equal(num.toString());
         r.end(true);
         done();
       });
@@ -275,14 +278,14 @@ describe("hincrbyfloat", function () {
 
     var r = redismock.createClient();
 
-    r.hincrbyfloat(testHash, testKey, 2.591, function (err, result) {
-      result.should.equal("2.591");
+    r.hincrbyfloat(testHash, testKey, num, function (err, result) {
+      result.should.equal(x2.toString());
 
-      r.hincrbyfloat(testHash, testKey, 2.591, function (err, result) {
-          result.should.equal("5.182");
+      r.hincrbyfloat(testHash, testKey, num, function (err, result) {
+          result.should.equal(x3.toString());
 
           r.hget(testHash, testKey, function (err, result) {
-              result.should.equal("5.182");
+              result.should.equal(x3.toString());
 
               r.end(true);
 
@@ -300,7 +303,7 @@ describe("hincrbyfloat", function () {
 
 describe("hsetnx", function () {
 
-  var testHash = "myHash";
+  var testHash = "myHashSetNx";
   var testKey = "myKey";
   var testKey2 = "myKey2";
   var testValue = "myValue";
@@ -361,6 +364,8 @@ describe("multiple get/set", function () {
 
   var mHash = "mHash";
   var mHash2 = "mHash2";
+  var mHash3 = "mHash3";
+  var mHash4 = "mHash4";
   var mHashEmpty = "mHashEmpty";
   var mKey1 = "mKey1";
   var mKey2 = "mKey2";
@@ -406,6 +411,38 @@ describe("multiple get/set", function () {
     var r = redismock.createClient();
 
     r.hmset(mHash, { mKey3: mValue3, mKey4: mValue4}, function (err, result) {
+
+      result.should.equal("OK");
+
+      r.end(true);
+
+      done();
+
+    });
+
+  });
+
+  it("should be able to set multiple keys using hash,array", function (done) {
+
+    var r = redismock.createClient();
+
+    r.hmset(mHash3, [mKey1, mValue1, mKey2, mValue2], function (err, result) {
+
+      result.should.equal("OK");
+
+      r.end(true);
+
+      done();
+
+    });
+
+  });
+
+  it("should be able to set multiple keys using array", function (done) {
+
+    var r = redismock.createClient();
+
+    r.hmset([mHash4, mKey1, mValue1, mKey2, mValue2], function (err, result) {
 
       result.should.equal("OK");
 

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -210,6 +210,8 @@ describe("getset", function () {
 
 describe("setex", function () {
 
+  this.timeout(5000);
+
   var r;
 
   beforeEach(function () {


### PR DESCRIPTION
node_redis supports a single array argument while calling hmset. See inlined comments for more details. Some of the comments might be overkill. Just let me know if you want me to remove them, or feel free to edit this PR.

- This straight up copies the same exact argument parsing from the node_redis hmset version. This moves the argument parsing into RedisClient.hmset and cleans up hmset in the hash module.

- Adds tests to support change. Also discovered some issues with existing test cases around hincrbyfloat, hsetnx, and setex.