### PR TITLE
LPUSH and RPUSH

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,3 +23,27 @@ exports.patternToRegex = function(pattern) {
   var fixed = pattern.replace(patternChanger, function(matched) { return charMap[matched] });
   return new RegExp('^' + fixed + '$');
 }
+
+var mockCallback = exports.mockCallback = function(err, reply) {};
+
+var parseCallback = exports.parseCallback = function(args) {
+  var callback;
+  var len = args.length;
+  if ('function' === typeof args[len - 1]) {
+    callback = args[len-1];
+  }
+  return callback;
+};
+
+var validKeyType = exports.validKeyType = function(mockInstance, key, type, callback) {
+  if (mockInstance.storage[key] && mockInstance.storage[key].type !== type) {
+    var err = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
+    mockInstance._callCallback(callback, err);
+    return false;
+  }
+  return true;
+};
+
+var initKey = exports.initKey = function(mockInstance, key, fn) {
+  mockInstance.storage[key] = mockInstance.storage[key] || fn();
+};

--- a/lib/list.js
+++ b/lib/list.js
@@ -1,4 +1,16 @@
+var helpers = require("./helpers.js");
 var Item = require("./item.js");
+
+
+var mockCallback = helpers.mockCallback;
+
+var validKeyType = function(mockInstance, key, callback) {
+  return helpers.validKeyType(mockInstance, key, 'list', callback)
+};
+
+var initKey = function(mockInstance, key) {
+  return helpers.initKey(mockInstance, key, Item.createList);
+};
 
 /**
  * Llen
@@ -8,13 +20,32 @@ exports.llen = function (mockInstance, key, callback) {
   mockInstance._callCallback(callback, null, length);
 };
 
-var push = function (fn, mockInstance, key, values, callback) {
-  if (mockInstance.storage[key] && mockInstance.storage[key].type !== "list") {
-    return mockInstance._callCallback(callback,
-      new Error("ERR Operation against a key holding the wrong kind of value"));
+var push = function (fn, args) {
+  var len = args.length;
+  if (len < 2) {
+    return
   }
-  mockInstance.storage[key] = mockInstance.storage[key] || new Item.createList();
+  var mockInstance = args[0];
+  var key = args[1];
+  var callback = helpers.parseCallback(args);
+  if (callback == undefined) {
+    callback = mockCallback;
+  }
+  if (!validKeyType(mockInstance, key, callback)) {
+    return
+  }
+  // init key
+  initKey(mockInstance, key);
 
+  // parse only the values from the args;
+  var values = [];
+  for (var i=2, val; i < len; i++) {
+    val = args[i];
+    if ('function' == typeof val) {
+      break;
+    }
+    values.push(val);
+  }
   fn.call(mockInstance.storage[key], values);
   var length = mockInstance.storage[key].value.length;
   pushListWatcher.pushed(key);
@@ -24,15 +55,15 @@ var push = function (fn, mockInstance, key, values, callback) {
 /**
  * Lpush
  */
-exports.lpush = function (mockInstance, key, values, callback) {
-  push(Item._list.prototype.lpush, mockInstance, key, values, callback);
+exports.lpush = function () {
+  push(Item._list.prototype.lpush, arguments);
 };
 
 /**
  * Rpush
  */
-exports.rpush = function (mockInstance, key, values, callback) {
-  push(Item._list.prototype.rpush, mockInstance, key, values, callback);
+exports.rpush = function () {
+  push(Item._list.prototype.rpush, arguments);
 };
 
 var pushx = function (fn, mockInstance, key, value, callback) {

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -442,33 +442,14 @@ RedisClient.prototype.llen = RedisClient.prototype.LLEN = function (key, callbac
   listfunctions.llen.call(this, MockInstance, key, callback);
 }
 
-var push = function (fn, key, values, callback) {
-  var vals = [];
-  var hasCallback = typeof(arguments[arguments.length - 1]) === "function";
-  for (var i = 2; i < (hasCallback ? arguments.length - 1 : arguments.length); i++) {
-    vals.push(arguments[i]);
-  }
-  if (hasCallback) {
-    fn.call(this, MockInstance, key, vals, arguments[arguments.length - 1]);
-  } else {
-    fn.call(this, MockInstance, key, vals);
-  }
+RedisClient.prototype.lpush = RedisClient.prototype.LPUSH = function () {
+  var args = parseArguments(arguments);
+  listfunctions.lpush.apply(this, [MockInstance].concat(args));
 }
 
-RedisClient.prototype.lpush = RedisClient.prototype.LPUSH = function (key, values, callback) {
-  var args = [listfunctions.lpush];
-  for (var i = 0; i < arguments.length; i++) {
-    args.push(arguments[i]);
-  }
-  push.apply(this, args);
-}
-
-RedisClient.prototype.rpush = RedisClient.prototype.RPUSH = function (key, values, callback) {
-  var args = [listfunctions.rpush];
-  for (var i = 0; i < arguments.length; i++) {
-    args.push(arguments[i]);
-  }
-  push.apply(this, args);
+RedisClient.prototype.rpush = RedisClient.prototype.RPUSH = function () {
+  var args = parseArguments(arguments);
+  listfunctions.rpush.apply(this, [MockInstance].concat(args));
 }
 
 RedisClient.prototype.lpushx = RedisClient.prototype.LPUSHX = function (key, value, callback) {

--- a/lib/sortedset.js
+++ b/lib/sortedset.js
@@ -1,4 +1,5 @@
-var Item = require('./item.js');
+var helpers = require("./helpers.js");
+var Item = require("./item.js");
 
 /**
 
@@ -30,20 +31,14 @@ var Item = require('./item.js');
 var MAX_SCORE_VALUE = 9007199254740992;
 var MIN_SCORE_VALUE = -MAX_SCORE_VALUE;
 
-var mockCallback = function(err, reply) {};
+var mockCallback = helpers.mockCallback;
 
 var validKeyType = function(mockInstance, key, callback) {
-  if (mockInstance.storage[key] && mockInstance.storage[key].type !== 'sortedset') {
-    var err = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
-    mockInstance._callCallback(callback, err);
-    return false;
-  }
-  return true;
+  return helpers.validKeyType(mockInstance, key, 'sortedset', callback)
 }
 
 var initKey = function(mockInstance, key) {
-  mockInstance.storage[key] = mockInstance.storage[key] ||
-                                new Item.createSortedSet();
+  return helpers.initKey(mockInstance, key, Item.createSortedSet);
 }
 
 // delimiter for lexicographically sorting by score & member
@@ -274,15 +269,6 @@ var getRangeByScore = function(
 
 }
 
-var parseCallback = function(args) {
-  var callback;
-  var len = args.length;
-  if ('function' === typeof args[len - 1]) {
-    callback = args[len-1];
-  }
-  return callback;
-};
-
 // ZADD key [NX|XX] [CH] [INCR] score member [score member ...]
 // Add one or more members to a sorted set, or update its score if it already exists
 exports.zadd = function(mockInstance, key) {
@@ -291,7 +277,7 @@ exports.zadd = function(mockInstance, key) {
   if (len <= 3) {
     return
   }
-  var callback = parseCallback(arguments);
+  var callback = helpers.parseCallback(arguments);
   if (!validKeyType(mockInstance, key, callback)) {
     return
   }
@@ -479,7 +465,7 @@ exports.zrem = function(mockInstance, key) {
     return
   }
 
-  var callback = parseCallback(arguments);
+  var callback = helpers.parseCallback(arguments);
   if (callback == undefined) {
     callback = mockCallback;
   }

--- a/test/redis-mock.list.test.js
+++ b/test/redis-mock.list.test.js
@@ -54,6 +54,30 @@ describe("basic pushing/poping list", function () {
     });
   });
 
+  it("should check a single rpush array arg works", function (done) {
+    var r = redismock.createClient();
+    r.rpush([testKey, testValue], function (err, result) {
+      result.should.equal(1);
+      r.rpop(testKey, function (err, result) {
+        result.should.equal(testValue + "");
+        r.end(true);
+        done();
+      });
+    });
+  });
+
+  it("should check a single lpush array arg works", function (done) {
+    var r = redismock.createClient();
+    r.lpush([testKey, testValue], function (err, result) {
+      result.should.equal(1);
+      r.rpop(testKey, function (err, result) {
+        result.should.equal(testValue + "");
+        r.end(true);
+        done();
+      });
+    });
+  });
+
   it("should be a queue", function (done) {
     var r = redismock.createClient();
     r.lpush(testKey, testValue, function (err, result) {


### PR DESCRIPTION
This changes the argument parsing for LPUSH and RPUSH so the client methods support an array as the first argument, like this:

```
lpush(['key1', 'v', 'v2'], callback);
or
rpush(['key2', 'v', 'v2'], callback);
```

This change also refactors previous code into the helpers module for easier reuse.