### PR TITLE
Various fixes to multi

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Currently implemented are the following redis commands:
 * auth
 * end
 * multi
+  * exec
+  * discard
 
 ### Events
 * ready

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -1,10 +1,11 @@
 
-var Multi = function(client) {
+var Multi = function(client, MockInterface) {
+  this._MockInterface = MockInterface
   this._client = client;
   this._commands = [];
   this._results = [];
   this._errors = [];
-  this._unfinishedCount = 0;
+  this._discarded = false;
 };
 
 /**
@@ -23,9 +24,8 @@ Multi.prototype._command = function(name, argList) {
     args = args.slice(0, args.length-1);
   }
 
-  self._unfinishedCount++;
-
-  // Add a custom callback that checks to see if other commands are finished
+  // Add a custom callback that chains the next commands,
+  // or to terminate the queue.
   var command = args.concat(function (err, result) {
     if(callBack) {
       callBack(err, result);
@@ -34,9 +34,15 @@ Multi.prototype._command = function(name, argList) {
     self._errors[index] = err;
     self._results[index] = result;
 
-    self._unfinishedCount--;
-    if (self._unfinishedCount === 0) {
+    var nextIndex = index + 1;
+
+    if (self._commands.length === nextIndex) {
       self._done();
+    } else {
+      var next = function() {
+        self._commands[nextIndex]();
+      }
+      self._MockInterface._callCallback(next)
     }
   });
 
@@ -64,13 +70,29 @@ Multi.prototype._done = function () {
 };
 
 /**
- * run all commands in the queue
+ * starts running all commands in the queue
  */
 Multi.prototype.exec = function (callback) {
   this._doneCallback = callback;
-  this._commands.forEach(function (command) {
-    command();
-  });
+  if(this._discarded) {
+    this._MockInterface._callCallback(callback, new Error("ERR EXEC without MULTI"));
+  } else {
+    if(this._commands.length == 0) {
+      this._MockInterface._callCallback(callback, null, []);
+    } else {
+      this._commands[0]();
+    }
+  }
+  return this;
+};
+
+/**
+ * discards the queue
+ */
+Multi.prototype.discard = function (callback) {
+  this._doneCallback = callback;
+  this._commands.length = 0;
+  this._discarded = true;
   return this;
 };
 
@@ -153,8 +175,8 @@ makeCommands([
   'zscore'
 ]);
 
-var multi = function (commands) {
-  var result = new Multi(this);
+var multi = function (client, MockInterface, commands) {
+  var result = new Multi(client, MockInterface);
   if(commands) {
     commands.forEach(function (command) {
       result._command(command[0], command.slice(1));
@@ -163,4 +185,4 @@ var multi = function (commands) {
   return result;
 };
 
-module.exports = multi;
+module.exports.multi = multi;

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -188,7 +188,9 @@ RedisClient.prototype.publish = function (channel, msg) {
  * multi
  */
 var multi = require("./multi");
-RedisClient.prototype.multi = multi;
+RedisClient.prototype.multi = function(commands) {
+  return multi.multi(this, MockInstance, commands)
+}
 
 /**
  * Keys function

--- a/test/redis-mock.multi.js
+++ b/test/redis-mock.multi.js
@@ -24,6 +24,15 @@ describe("multi()", function () {
   });
 
   describe("exec()", function () {
+    it("should handle empty queues", function (done) {
+      var multi = r.multi();
+      multi.exec(function (err, results) {
+        should(err).not.be.ok();
+        should.deepEqual(results, []);
+        done();
+      });
+    });
+
     it("should handle things without errors and callbacks", function (done) {
       var multi = r.multi();
       multi.get('foo').incr('foo');
@@ -58,5 +67,44 @@ describe("multi()", function () {
       }).exec();
     });
 
+    it("should run sorted set operations in order", function (done) {
+      r.zadd('myzset', 1, 'a');
+      r.zadd('myzset', 2, 'b');
+      r.multi().
+        zremrangebyscore('myzset', 0, 1).
+        zadd('myzset', 'NX', 3, 'a').
+        exec(function (err, result) {
+          should(err).not.be.ok();
+          should.deepEqual(result, [1, 1]);
+          done();
+        });
+    });
+  });
+
+  describe("discard()", function () {
+    it("should properly discard the command queue", function (done) {
+      r.set('foo', 3, function() {
+        var multi = r.multi()
+        multi.incr('foo', function () {
+          // Discarded queues aren't calling their callbacks.
+          should.not.be.ok(true);
+        })
+        multi.discard();
+        r.get('foo', function (err, value) {
+          value.should.eql('3')
+          done();
+        });
+      });
+    });
+
+    it("should now allow to re-run the command queue", function (done) {
+      var multi = r.multi()
+      multi.discard()
+      multi.exec(function (err, value) {
+        should(value).not.be.ok();
+        err.should.be.ok();
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
-) fixing #24 - ordering of multi means chaining of the queued commands
-) adds the discard keyword to multi
-) fixes empty queue calls