### PR TITLE
Fixing atomicity of multis.

### DIFF
--- a/lib/multi.js
+++ b/lib/multi.js
@@ -6,6 +6,7 @@ var Multi = function(client, MockInterface) {
   this._results = [];
   this._errors = [];
   this._discarded = false;
+  this._callbacks = [];
 };
 
 /**
@@ -28,7 +29,12 @@ Multi.prototype._command = function(name, argList) {
   // or to terminate the queue.
   var command = args.concat(function (err, result) {
     if(callBack) {
-      callBack(err, result);
+      self._callbacks.push(function() {
+        callBack(err, result);
+        if (self._callbacks.length !== 0) {
+          self._MockInterface._callCallback(self._callbacks.shift());
+        }
+      });
     }
 
     self._errors[index] = err;
@@ -37,7 +43,10 @@ Multi.prototype._command = function(name, argList) {
     var nextIndex = index + 1;
 
     if (self._commands.length === nextIndex) {
-      self._done();
+      self._callbacks.push(function() {
+        self._done();
+      });
+      self._MockInterface._callCallback(self._callbacks.shift());
     } else {
       var next = function() {
         self._commands[nextIndex]();

--- a/test/redis-mock.multi.js
+++ b/test/redis-mock.multi.js
@@ -79,6 +79,22 @@ describe("multi()", function () {
           done();
         });
     });
+
+    it("should run atomically with its own callbacks", function (done) {
+      var multi = r.multi();
+      multi.set('key', 0, function() {
+        r.set('key', 0)
+      });
+      multi.incr('key', function() {
+        r.incr('key');
+      });
+      multi.exec(function() {
+        r.get('key', function(err, value) {
+          value.should.eql('1')
+          done();
+        });
+      });
+    });
   });
 
   describe("discard()", function () {


### PR DESCRIPTION
The added test would fail only on redis-mock without the rest of the change :-) This is a bug I realized I introduced in #33, but now there's a regression test.