### PR TITLE
#42 exports Multi module for promisify exec function

### DIFF
--- a/lib/multi.js
+++ b/lib/multi.js
@@ -198,3 +198,4 @@ var multi = function (client, MockInterface, commands) {
 };
 
 module.exports.multi = multi;
+module.exports.Multi = Multi;

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -191,6 +191,7 @@ var multi = require("./multi");
 RedisClient.prototype.multi = function(commands) {
   return multi.multi(this, MockInstance, commands)
 }
+exports.Multi = multi.Multi;
 
 /**
  * Keys function


### PR DESCRIPTION
for issue #42.
I use bluebird for Async function, but cannot Promisify exec function.

According to redis-doc, Promissify exec function  will be the following code.

> bluebird.promisifyAll(redis.Multi.prototype);

There is no prototype in multi of redis-mock, so please open Multi.

Best regards,