### PR TITLE
Fix error in SISMEMBER when target key is unset

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -80,7 +80,7 @@ exports.sismember = function (mockInstance, key, member, callback) {
     }
   }
   member = Item._stringify(member);
-  var count = (mockInstance.storage[key].value.indexOf(member) > -1) ? 1 : 0;
+  var count = (mockInstance.storage[key] && (mockInstance.storage[key].value.indexOf(member) > -1)) ? 1 : 0;
   mockInstance._callCallback(callback, null, count);
 }
 

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -194,13 +194,30 @@ describe('srem', function () {
 describe('sismember', function () {
 
   it('should test if member exists', function (done) {
-
     var r = redismock.createClient();
     r.sadd('foo2', 'bar', 'baz', 'qux', function (err, result) {
       r.sismember('foo2', 'bar', function (err, result) {
         result.should.eql(1);
         done();
       });
+    });
+  });
+
+  it('should return 0 if member does not exist', function(done) {
+    var r = redismock.createClient();
+    r.sadd('foo2', 'bar', 'baz', function (err, result) {
+      r.sismember('foo2', 'qux', function(err, result) {
+        result.should.eql(0);
+        done();
+      });
+    });
+  });
+
+  it('should return 0 if key is not set', function(done) {
+    var r = redismock.createClient();
+    r.sismember('foo3', 'bar', function(err, result) {
+      result.should.eql(0);
+      done();
     });
   });
 


### PR DESCRIPTION
Fixes:
```
    TypeError: Cannot read property 'value' of undefined
        at RedisClient.exports.sismember (/node_modules/redis-mock/lib/set.js:83:41)
        at RedisClient.sismember.RedisClient.SISMEMBER (/node_modules/redis-mock/lib/redis-mock.js:571:26)
```