### PR TITLE
[RFR] Add support for PTTL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ FLAGS=--reporter $(REPORTER)
 run-tests:
 	@./node_modules/.bin/mocha --timeout 3000 $(TESTS) $(FLAGS)
 
+watch-tests:
+	@./node_modules/.bin/mocha --timeout 3000 --watch $(TESTS) $(FLAGS)
+
 test:
 	@$(MAKE) NODE_PATH=lib TESTS="$(ALL_TESTS)" run-tests
 

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -66,7 +66,7 @@ exports.expire = function (mockInstance, key, seconds, callback) {
  * TTL
  * http://redis.io/commands/ttl
  */
-exports.ttl = function (mockInstance, key, callback) {
+var ttl = function (mockInstance, key, callback) {
   var result = 0;
 
   var obj = mockInstance.storage[key];
@@ -89,13 +89,22 @@ exports.ttl = function (mockInstance, key, callback) {
   mockInstance._callCallback(callback, null, result);
 };
 
+exports.ttl = ttl;
+
+exports.pttl = function (mockInstance, key, callback) {
+  return ttl(mockInstance, key, function(err, ttl) {
+    var computedTtl = ttl > 0 ? ttl * 1000 : ttl;
+    mockInstance._callCallback(callback, err, computedTtl);
+  });
+};
+
 /**
  * Keys
  */
 exports.keys = function (mockInstance, pattern, callback) {
   var regex = patternToRegex(pattern);
   var keys = [];
-  
+
   for (var key in mockInstance.storage) {
     if (regex.test(key)) {
       keys.push(key);

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -157,6 +157,7 @@ makeCommands([
   'mset',
   'msetnx',
   'ping',
+  'pttl',
   'rpop',
   'rpush',
   'rpushx',

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -217,6 +217,10 @@ RedisClient.prototype.ttl = RedisClient.prototype.TTL = function (key, callback)
   keyfunctions.ttl.call(this, MockInstance, key, callback);
 };
 
+RedisClient.prototype.pttl = RedisClient.prototype.PTTL = function (key, callback) {
+  keyfunctions.pttl.call(this, MockInstance, key, callback);
+};
+
 RedisClient.prototype.keys = RedisClient.prototype.KEYS = function (pattern, callback) {
 
   keyfunctions.keys.call(this, MockInstance, pattern, callback);

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -220,6 +220,67 @@ describe("ttl", function () {
 
 });
 
+describe("pttl", function () {
+  var r;
+  beforeEach(function () {
+    r = redismock.createClient();
+  });
+
+  it("should return remaining time before expiration in milliseconds", function (done) {
+    r.set("test", "test", function (err, result) {
+      r.expire("test", 100, function (err, result) {
+        result.should.equal(1);
+
+        setTimeout(function () {
+          r.pttl("test", function (err, pttl) {
+            if (err) {
+              done(err);
+            }
+
+            pttl.should.be.within(98000, 99000);
+            r.del("test");
+            r.end(true);
+
+            done();
+          });
+        }, 1500);
+      });
+
+    });
+
+  });
+
+  it("should return -2 for non-existing key", function (done) {
+    r.pttl("test", function (err, ttl) {
+      if (err) {
+        done(err);
+      }
+
+      ttl.should.equal(-2);
+      r.end(true);
+
+      done();
+    });
+  });
+
+  it("should return -1 for an existing key with no EXPIRE", function (done) {
+    r.set("test", "test", function (err, result) {
+      r.pttl("test", function (err, ttl) {
+        if (err) {
+          done(err);
+        }
+
+        ttl.should.equal(-1);
+        r.del("test");
+        r.end(true);
+
+        done();
+      });
+    });
+  });
+
+});
+
 describe("keys", function () {
 
   var r = redismock.createClient();
@@ -250,7 +311,7 @@ describe("keys", function () {
       keys.should.have.length(2);
       keys.should.containEql('hello');
       keys.should.containEql('hallo');
-      
+
       done();
     });
   });
@@ -273,7 +334,7 @@ describe("keys", function () {
       keys.should.containEql('hello');
       keys.should.containEql('hallo');
       keys.should.containEql('hxlo');
-      
+
       done();
     });
   });


### PR DESCRIPTION
Current implementation misses the [PTTL command](https://redis.io/commands/pttl), which returns the TTL in milliseconds. 

I wasn't able to run the `make check-tests` command locally as I don't have any Redis locally installed. Yet, the `make test` command works.