### PR TITLE
fix(sortedSet): sort correctly

### DIFF
--- a/lib/sortedset.js
+++ b/lib/sortedset.js
@@ -51,11 +51,20 @@ var getRankedList = function(mockInstance, key) {
   // returns a ranked list of items (k)
   var items = [];
   for (var member in mockInstance.storage[key].value) {
-    var score = mockInstance.storage[key].value[member];
-    items.push(score + rankedDelimiter + member);
+    var score = parseFloat(mockInstance.storage[key].value[member]);
+    items.push([score, score + rankedDelimiter + member]);
   }
-  items.sort();
-  return items;
+
+  //first sort by score then alphabetically
+  items.sort(
+    function (a, b) {
+      return a[0] - b[0] || a[1].localeCompare(b[1]);
+    });
+
+  //return the concatinated values
+  return items.map(function (value, index) {
+    return value[1];
+  });
 }
 
 /*

--- a/test/redis-mock.sortedset.test.js
+++ b/test/redis-mock.sortedset.test.js
@@ -439,7 +439,9 @@ describe("zrevrange", function () {
     1.2, 'm1.2',
     1.3, 'm1.3',
     1.4, 'm1.4',
-    1.5, 'm1.5'
+    1.5, 'm1.5',
+    10, 'm10',
+    10, 'm11'
   ];
 
   var aLen = args.length;
@@ -450,8 +452,10 @@ describe("zrevrange", function () {
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey1, '0', '-1', 'withscores'], function(err, result) {
-        should(result[0]).equal('m3');
-        should(result[1]).equal('3');
+        should(result[0]).equal('m11');
+        should(result[1]).equal('10');
+        should(result[2]).equal('m10');
+        should(result[3]).equal('10');
         should(result.length).equal(aLen);
         done();
       });
@@ -463,10 +467,10 @@ describe("zrevrange", function () {
     r.zadd([testKey2].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey2, '1', '5', 'withscores'], function(err, result) {
-        should(result[0]).equal('m2');
-        should(result[1]).equal('2');
-        should(result[2]).equal('m1.5');
-        should(result[3]).equal('1.5');
+        should(result[0]).equal('m10');
+        should(result[1]).equal('10');
+        should(result[2]).equal('m3');
+        should(result[3]).equal('3');
         should(result.length).equal(5 * 2);
         done();
       });
@@ -477,9 +481,9 @@ describe("zrevrange", function () {
     var r = redismock.createClient();
     r.zadd([testKey3].concat(args), function(err, result) {
       r.zrevrange([testKey3, '0', '-1'], function(err, result) {
-        should(result[0]).equal('m3');
-        should(result[1]).equal('m2');
-        should(result[2]).equal('m1.5');
+        should(result[0]).equal('m11');
+        should(result[1]).equal('m10');
+        should(result[2]).equal('m3');
         should(result.length).equal(mLen);
         done();
       });
@@ -491,8 +495,8 @@ describe("zrevrange", function () {
     r.zadd([testKey4].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey4, '1', '5'], function(err, result) {
-        should(result[0]).equal('m2');
-        should(result[1]).equal('m1.5');
+        should(result[0]).equal('m10');
+        should(result[1]).equal('m3');
         should(result.length).equal(5);
         done();
       });


### PR DESCRIPTION
First sort using the score
Then sort alphabetically

The issue was that the mock tests did not take into account multi digit scores so they pass. The mock code uses strings which means it will incorrectly compare "1" and "10" for example.

**NOTE**
This only tests zrevrange. If `10, 'm10'` and `10, 'm11'` are added to other sorted tests they fail. While this change is testing the sort overall via zrevrange, other tests should be eventually updated to account for this change as well. 

Given following set:
```
    1, 'm1',
    2, 'm2',
    3, 'm3',
    1.1, 'm1.1',
    1.2, 'm1.2',
    1.3, 'm1.3',
    1.4, 'm1.4',
    1.5, 'm1.5',
    10, 'm10',
    10, 'm11'
```
  
Mock was returning:
```
[
  "m3",
  "3",
  "m2",
  "2",
  "m11",
  "10",
  "m10",
  "10",
  "m1.5",
  "1.5",
  "m1.4",
  "1.4",
  "m1.3",
  "1.3",
  "m1.2",
  "1.2",
  "m1.1",
  "1.1",
  "m1",
  "1"
]
```
  
Redis was returning:
```
> zrevrange test 0 -1 WITHSCORES
1) "m11"
2) 10.0
3) "m10"
4) 10.0
5) "m3"
6) 3.0
7) "m2"
8) 2.0
9) "m1.5"
10) 1.5
11) "m1.4"
12) 1.4
13) "m1.3"
14) 1.3
15) "m1.2"
16) 1.2
17) "m1.1"
18) 1.1
19) "m1"
20) 1.0
```