### PR TITLE
Allow documented parameters to the redis SET function

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -5,7 +5,7 @@ var events = require("events"),
   util = require("util");
 
 
-var parseArguments = function(args) {
+var parseArguments = function(args, options) {
   var arr,
       len = args.length,
       callback,
@@ -35,8 +35,12 @@ var parseArguments = function(args) {
         // arg1 = {k1: v1, k2: v2,}
         // arg2 = callback
         arr = [args[0]];
-        for (var field in args[1]) {
-            arr.push(field, args[1][field]);
+        if(options && options.valueIsString) {
+           arr.push(args[1].toString());
+        } else {
+           for (var field in args[1]) {
+               arr.push(field, args[1][field]);
+           }
         }
         callback = args[2];
   } else {
@@ -259,11 +263,7 @@ RedisClient.prototype.getset = RedisClient.prototype.GETSET = function (key, val
 
 //SET key value [EX seconds] [PX milliseconds] [NX|XX]
 RedisClient.prototype.set = RedisClient.prototype.SET = function (key, value, callback) {
-    var args = [];
-
-    for (var i = 0; i < arguments.length; i++) {
-        args.push(arguments[i]);
-    }
+    var args = parseArguments(arguments, {valueIsString: true});
 
     key = args.shift();
     value = args.shift();

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -42,6 +42,42 @@ describe("set", function () {
     });
   });
 
+  it("should allow arrays as first argument to the set function", function (done) {
+
+    var r = redismock.createClient();
+
+    r.set(["foo", "bar"], function (err, result) {
+      result.should.equal("OK");
+
+          r.get("foo", function (err, result) {
+
+            result.should.equal("bar");
+
+            r.end(true);
+
+            done();
+
+          });
+    });
+  });
+  it("should allow redis arguments to the set function", function (done) {
+
+    var r = redismock.createClient();
+
+    r.set("foo", "bar", 'EX', 10, function (err, result) {
+      result.should.equal("OK");
+
+          r.get("foo", function (err, result) {
+
+            result.should.equal("bar");
+
+            r.end(true);
+
+            done();
+
+          });
+    });
+  });
   it("should toString() values", function (done) {
 
     var r = redismock.createClient();


### PR DESCRIPTION
The redis set function allows parameters to be passed as an array.

However, the special snowflake converting the object passed as a second parameter through toString() has to be handled as well.

Note: that behaviour will be removed in a future version of redis (if not already done) 