### PR TITLE
Add support for buffers for string operations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,10 +3,10 @@ REPORTER?=spec
 FLAGS=--reporter $(REPORTER)
 
 run-tests:
-	@./node_modules/.bin/mocha --timeout 3000 $(TESTS) $(FLAGS)
+	@./node_modules/.bin/mocha --timeout 5000 $(TESTS) $(FLAGS)
 
 watch-tests:
-	@./node_modules/.bin/mocha --timeout 3000 --watch $(TESTS) $(FLAGS)
+	@./node_modules/.bin/mocha --timeout 5000 --watch $(TESTS) $(FLAGS)
 
 test:
 	@$(MAKE) NODE_PATH=lib TESTS="$(ALL_TESTS)" run-tests

--- a/lib/item.js
+++ b/lib/item.js
@@ -30,6 +30,15 @@ var RedisString = function (value, expires) {
 util.inherits(RedisString, RedisItem);
 
 /**
+ * Constructor of a buffer
+ */
+var RedisBuffer = function (value, expires) {
+  RedisItem.call(this, "buffer", expires);
+  this.value = (value instanceof Buffer) ? value : new Buffer(value);
+};
+util.inherits(RedisBuffer, RedisItem);
+
+/**
  * Constructor of an hash
  */
 var RedisHash = function () {
@@ -86,6 +95,7 @@ util.inherits(RedisSortedSet, RedisItem);
 var RedisItemFactory = {
   _item: RedisItem,
   _string: RedisString,
+  _buffer: RedisBuffer,
   _hash: RedisHash,
   _list: RedisList,
   _set: RedisSet,
@@ -95,6 +105,10 @@ var RedisItemFactory = {
 
 RedisItemFactory.createString = function (elt, expire) {
   return new RedisString(elt, expire);
+};
+
+RedisItemFactory.createBuffer = function (elt, expire) {
+  return new RedisBuffer(elt, expire);
 };
 
 RedisItemFactory.createHash = function () {

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -37,6 +37,8 @@ var parseArguments = function(args, options) {
         arr = [args[0]];
         if(options && options.valueIsString) {
            arr.push(args[1].toString());
+        } else if(options && options.valueIsBuffer) {
+           arr.push(args[1]);
         } else {
            for (var field in args[1]) {
                arr.push(field, args[1][field]);
@@ -263,7 +265,9 @@ RedisClient.prototype.getset = RedisClient.prototype.GETSET = function (key, val
 
 //SET key value [EX seconds] [PX milliseconds] [NX|XX]
 RedisClient.prototype.set = RedisClient.prototype.SET = function (key, value, callback) {
-    var args = parseArguments(arguments, {valueIsString: true});
+    var isBuffer = (value instanceof Buffer);
+    var isString = !isBuffer;
+    var args = parseArguments(arguments, { valueIsBuffer: isBuffer, valueIsString: isString });
 
     key = args.shift();
     value = args.shift();

--- a/lib/strings.js
+++ b/lib/strings.js
@@ -1,11 +1,21 @@
 var Item = require("./item.js");
 
+// Create a string or buffer Item depending on input value
+function createItem(value) {
+  return (value instanceof Buffer) ? Item.createBuffer(value) : Item.createString(value);
+}
+
+// Allowable types for string operations
+function validType(item) {
+  return item.type === 'string' || item.type === 'buffer';
+}
+
 /**
  * Set
  */
 exports.set = function (mockInstance, key, value, callback) {
 
-  mockInstance.storage[key] = Item.createString(value);
+  mockInstance.storage[key] = createItem(value);
 
   mockInstance._callCallback(callback, null, "OK");
 };
@@ -39,11 +49,20 @@ exports.get = function (mockInstance, key, callback) {
   var value = null;
   var err = null;
 
-  if (mockInstance.storage[key]) {
-    if (mockInstance.storage[key].type !== "string") {
+  var storedValue = mockInstance.storage[key];
+  if (storedValue) {
+    if (!validType(storedValue)) {
       err = new Error("WRONGTYPE Operation against a key holding the wrong kind of value");
-    } else {
-      value = mockInstance.storage[key].value;
+    } else if (storedValue.type === 'string') {
+      value = storedValue.value;
+      if (key instanceof Buffer) {
+        value = new Buffer(value);
+      }
+    } else if (storedValue.type === 'buffer') {
+      value = storedValue.value;
+      if (typeof key === 'string') {
+        value = value.toString();
+      }
     }
   }
 
@@ -59,8 +78,8 @@ exports.getset = function (mockInstance, key, value, callback) {
     if (err) {
       return mockInstance._callCallback(callback, err, null);
     }
-  
-    mockInstance.storage[key] = Item.createString(value);
+
+    mockInstance.storage[key] = createItem(value);
 
     mockInstance._callCallback(callback, err, oldValue);
   });
@@ -88,15 +107,13 @@ exports.mget = function (mockInstance) {
 
   var values = [];
   for (var j = 0; j < keys.length; j++) {
-    if (mockInstance.storage[keys[j]]) {
-      if (mockInstance.storage[keys[j]].type !== 'string') {
-        err = new Error("ERR Operation against key " + keys[j] + " holding wrong kind of value");
+    exports.get(mockInstance, keys[j], function(e, value) {
+      if (e) {
+        err = e;
       } else {
-        values.push(mockInstance.storage[keys[j]].value);
+        values.push(value);
       }
-    } else {
-      values.push(null);
-    }
+    });
   }
 
   if ('function' === typeof arguments[arguments.length - 1]) {

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -1,0 +1,17 @@
+var redismock = require("../");
+
+if (process.env['VALID_TESTS']) {
+  redismock = require('redis');
+}
+
+function createClient() {
+  var options = {
+    detect_buffers: true,
+    url: process.env['REDIS_URL'] || 'redis://127.0.0.1:6379'
+  }
+  return redismock.createClient(options);
+}
+
+module.exports = {
+  createClient: createClient
+};

--- a/test/redis-mock.connection.test.js
+++ b/test/redis-mock.connection.test.js
@@ -1,39 +1,37 @@
-var redismock = require("../"),
-  should = require("should");
+var helpers = require("./helpers");
+var should = require("should");
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe("select", function() {
   it("should change database with using an integer", function(done) {
-    var r = redismock.createClient();
-
     r.select(2, function(err, result) {
       should.not.exist(err);
       result.should.equal('OK');
 
-      r.end(true);
       done();
     });
     
   });
   
   it('should error when using and invalid database value', function(done) {
-    var r = redismock.createClient();
-
     r.select('db', function(err, result) {
       should.not.exist(result);
       should(err).Error;
 
-      r.end(true);
       done();
     }); 
   });
   
   it('should not ensist on a callback', function() {
-    var r = redismock.createClient();
-
     r.select(3);
   });  
   

--- a/test/redis-mock.hash.test.js
+++ b/test/redis-mock.hash.test.js
@@ -1,10 +1,16 @@
-var redismock = require("../"),
-  should = require("should"),
-  events = require("events");
+var helpers = require("./helpers");
+var should = require("should");
+var events = require("events");
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe("basic hashing usage", function () {
 
@@ -16,12 +22,8 @@ describe("basic hashing usage", function () {
 
   it("should not say that non-existant values exist", function (done) {
 
-    var r = redismock.createClient();
-
     r.hexists(testHash, testKey, function (err, result) {
       result.should.equal(0);
-
-      r.end(true);
 
       done();
 
@@ -31,13 +33,9 @@ describe("basic hashing usage", function () {
 
   it("should set a value", function (done) {
 
-    var r = redismock.createClient();
-
     r.hset(testHash, testKey, testValue, function (err, result) {
 
       result.should.equal(1);
-
-      r.end(true);
 
       done();
 
@@ -47,15 +45,12 @@ describe("basic hashing usage", function () {
 
   it("should toString on non-string values", function (done) {
     var testArray = [1,2,3];
-    var r = redismock.createClient();
 
     r.hset(testHash, testKey, testArray, function (err, result) {
 
       r.hget(testHash, testKey, function (err, result) {
 
         result.should.equal(testArray.toString());
-
-        r.end(true);
 
         done();
 
@@ -68,7 +63,6 @@ describe("basic hashing usage", function () {
   describe("more complex set/get/exist...", function () {
 
     beforeEach(function (done) {
-      var r = redismock.createClient();
       r.hset(testHash, testKey, testValue, function (err, result) {
 
         done();
@@ -78,14 +72,10 @@ describe("basic hashing usage", function () {
 
     it("should refuse to get a string from an hash", function (done) {
 
-      var r = redismock.createClient();
-
       r.get(testHash, function (err, result) {
         should.not.exist(result);
 
         err.message.should.equal("WRONGTYPE Operation against a key holding the wrong kind of value");
-
-        r.end(true);
 
         done();
       });
@@ -93,13 +83,9 @@ describe("basic hashing usage", function () {
 
     it("should set a value in an existing hash and say it already existed", function (done) {
 
-      var r = redismock.createClient();
-
       r.hset(testHash, testKey, testValue, function (err, result) {
 
         result.should.equal(0);
-
-        r.end(true);
 
         done();
 
@@ -109,13 +95,9 @@ describe("basic hashing usage", function () {
 
     it("should get a value that has been set", function (done) {
 
-      var r = redismock.createClient();
-
       r.hget(testHash, testKey, function (err, result) {
 
         result.should.equal(testValue);
-
-        r.end(true);
 
         done();
 
@@ -125,12 +107,9 @@ describe("basic hashing usage", function () {
 
     it("should not get a value that has not been set", function (done) {
 
-      var r = redismock.createClient();
       r.hget(testHash, testKeyNotExist, function (err, result) {
 
         should.not.exist(result);
-
-        r.end(true);
 
         done();
 
@@ -140,13 +119,9 @@ describe("basic hashing usage", function () {
 
     it("should say that set value exists", function (done) {
 
-      var r = redismock.createClient();
-
       r.hexists(testHash, testKey, function (err, result) {
 
         result.should.equal(1);
-
-        r.end(true);
 
         done();
 
@@ -156,13 +131,9 @@ describe("basic hashing usage", function () {
 
     it("should delete a value", function (done) {
 
-      var r = redismock.createClient();
-
       r.hdel(testHash, testKey, function (err, result) {
 
         result.should.equal(1);
-
-        r.end(true);
 
         done();
 
@@ -172,13 +143,10 @@ describe("basic hashing usage", function () {
 
     it("should not get a value that has been deleted", function (done) {
 
-      var r = redismock.createClient();
       r.hdel(testHash, testKey, function (err, result) {
         r.hget(testHash, testKey, function (err, result) {
 
           should.not.exist(result);
-
-          r.end(true);
 
           done();
 
@@ -188,13 +156,10 @@ describe("basic hashing usage", function () {
 
     it("should not say that deleted value exists", function (done) {
 
-      var r = redismock.createClient();
       r.hdel(testHash, testKey, function (err, result) {
         r.hexists(testHash, testKey, function (err, result) {
 
           result.should.equal(0);
-
-          r.end(true);
 
           done();
 
@@ -205,13 +170,9 @@ describe("basic hashing usage", function () {
 
     it("should return length 0 when key does not exist", function (done) {
 
-      var r = redismock.createClient();
-
       r.hlen("newHash", function (err, result) {
 
         result.should.equal(0);
-
-        r.end(true);
 
         done();
 
@@ -219,8 +180,6 @@ describe("basic hashing usage", function () {
     });
 
     it("should return length when key exists", function (done) {
-
-      var r = redismock.createClient();
 
       r.hlen(testHash, function (err, result) {
 
@@ -231,8 +190,6 @@ describe("basic hashing usage", function () {
           r.hlen(testHash, function (err, result) {
 
             result.should.equal(2);
-
-            r.end(true);
 
             done();
 
@@ -250,17 +207,13 @@ describe("hincrby", function () {
   var testHash = "myHashToIncr";
   var testKey = "myKeyToIncr";
 
-
   it("should increment an attribute of the hash", function (done) {
-
-    var r = redismock.createClient();
 
     r.hincrby(testHash, testKey, 2, function (err, result) {
       result.should.equal(2);
 
       r.hget(testHash, testKey, function (err, result) {
         result.should.equal("2");
-        r.end(true);
         done();
       });
     });
@@ -275,20 +228,16 @@ describe("hincrbyfloat", function () {
   var testKey = "myKeyToIncrFloat";
   var testKey2 = "myKeyToIncrFloat2";
 
-
   var num = 2.591;
   var x2 = num * 2;
 
   it("should increment an attribute of the hash", function (done) {
-
-    var r = redismock.createClient();
 
     r.hincrbyfloat(testHash, testKey, num, function (err, result) {
       result.should.equal(num.toString());
 
       r.hget(testHash, testKey, function (err, result) {
         result.should.equal(num.toString());
-        r.end(true);
         done();
       });
     });
@@ -296,8 +245,6 @@ describe("hincrbyfloat", function () {
   });
 
   it("should double increment an attribute of the hash", function (done) {
-
-    var r = redismock.createClient();
 
     r.hincrbyfloat(testHash, testKey2, num, function (err, result) {
       result.should.equal(num.toString());
@@ -307,8 +254,6 @@ describe("hincrbyfloat", function () {
 
           r.hget(testHash, testKey2, function (err, result) {
               result.should.equal(x2.toString());
-
-              r.end(true);
 
               done();
           });
@@ -331,7 +276,6 @@ describe("hsetnx", function () {
   var testValue2 = "myNewTestValue";
 
   beforeEach(function (done) {
-    var r = redismock.createClient();
     r.hset(testHash, testKey, testValue, function (err, result) {
 
       done();
@@ -341,13 +285,9 @@ describe("hsetnx", function () {
 
   it("should set a value that does not exist", function (done) {
 
-    var r = redismock.createClient();
-
     r.hsetnx(testHash, testKey2, testValue, function (err, result) {
 
       result.should.equal(1);
-
-      r.end(true);
 
       done();
 
@@ -356,8 +296,6 @@ describe("hsetnx", function () {
   });
 
   it("should not set a value that does exist", function (done) {
-
-    var r = redismock.createClient();
 
     r.hsetnx(testHash, testKey, testValue2, function (err, result) {
 
@@ -368,8 +306,6 @@ describe("hsetnx", function () {
         result.should.not.equal(testValue2);
 
         result.should.equal(testValue);
-
-        r.end(true);
 
         done();
 
@@ -398,7 +334,6 @@ describe("multiple get/set", function () {
   var mValue4 = "mValue4";
 
   beforeEach(function (done) {
-    var r = redismock.createClient();
     r.hset(mHash2, mKey1, mValue1, function () {
       r.hset(mHash2, mKey2, mValue2, function () {
         r.hset(mHash2, mKey3, mValue3, function () {
@@ -413,13 +348,9 @@ describe("multiple get/set", function () {
   // HMSET
   it("should be able to set multiple keys as multiple arguments", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset(mHash, mKey1, mValue1, mKey2, mValue2, function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -427,13 +358,9 @@ describe("multiple get/set", function () {
   });
   it("should be able to set multiple keys as array", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset(mHash, [mKey1, mValue1, mKey2, mValue2], function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -442,13 +369,9 @@ describe("multiple get/set", function () {
 
   it("should be able to set hash and multiple keys as array", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset([mHash, mKey1, mValue1, mKey2, mValue2], function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -457,13 +380,9 @@ describe("multiple get/set", function () {
   it("should be able to set multiple keys as an object", function (done) {
 
 
-    var r = redismock.createClient();
-
     r.hmset(mHash, { mKey3: mValue3, mKey4: mValue4}, function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -473,13 +392,9 @@ describe("multiple get/set", function () {
 
   it("should be able to set multiple keys using hash,array", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset(mHash3, [mKey1, mValue1, mKey2, mValue2], function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -489,13 +404,9 @@ describe("multiple get/set", function () {
 
   it("should be able to set multiple keys using array", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset([mHash4, mKey1, mValue1, mKey2, mValue2], function (err, result) {
 
       result.should.equal("OK");
-
-      r.end(true);
 
       done();
 
@@ -506,15 +417,11 @@ describe("multiple get/set", function () {
   // HMGET
   it("should be able to get multiple keys as multiple arguments", function (done) {
 
-    var r = redismock.createClient();
-
     r.hmset(mHash, { mKey3: mValue3, mKey4: mValue4});
     r.hmget(mHash2, mKey1, mKey2, function (err, result) {
 
       result.should.be.an.Array().and.have.lengthOf(2);
       result.should.eql([mValue1, mValue2]);
-
-      r.end(true);
 
       done();
 
@@ -522,12 +429,10 @@ describe("multiple get/set", function () {
   });
 
   it("should return array of null values if key doesn't exist", function (done) {
-    var r = redismock.createClient();
 
     r.hmget("random", mKey1, mKey2, function (err, result) {
       result.should.be.an.Array().and.have.lengthOf(2);
       result.should.eql([null, null]);
-      r.end(true);
 
       done();
     });
@@ -536,16 +441,12 @@ describe("multiple get/set", function () {
   //HKEYS
   it("should be able to get all keys for hash", function (done) {
 
-    var r = redismock.createClient();
-
     r.hkeys(mHash2, function (err, result) {
 
       result.indexOf(mKey1).should.not.equal(-1);
       result.indexOf(mKey2).should.not.equal(-1);
       result.indexOf(mKey3).should.not.equal(-1);
       result.indexOf(mKey4).should.not.equal(-1);
-
-      r.end(true);
 
       done();
 
@@ -556,16 +457,12 @@ describe("multiple get/set", function () {
   //HVALS
   it("should be able to get all vals for hash", function (done) {
 
-    var r = redismock.createClient();
-
     r.hvals(mHash2, function (err, result) {
 
       result.should.containEql(mValue1);
       result.should.containEql(mValue2);
       result.should.containEql(mValue3);
       result.should.containEql(mValue4);
-
-      r.end(true);
 
       done();
 
@@ -576,8 +473,6 @@ describe("multiple get/set", function () {
   //HGETALL
   it("should be able to get all values for hash", function (done) {
 
-    var r = redismock.createClient();
-
     r.hgetall(mHash2, function (err, result) {
 
       should.exist(result);
@@ -587,20 +482,14 @@ describe("multiple get/set", function () {
       result.should.have.property(mKey3, mValue3);
       result.should.have.property(mKey4, mValue4);
 
-      r.end(true);
-
       done();
     });
   });
 
   it("should return null on a non existing hash", function (done) {
-    var r = redismock.createClient();
-
     r.hgetall(mHashEmpty, function (err, result) {
 
       should.not.exist(result);
-
-      r.end(true);
 
       done();
     });

--- a/test/redis-mock.item.test.js
+++ b/test/redis-mock.item.test.js
@@ -58,6 +58,27 @@ describe("createString", function () {
   });
 });
 
+describe("createBuffer", function () {
+  it('should return a buffer when passed a string', function () {
+    var elt = "foo";
+    var item = RedisItem.createBuffer(elt);
+
+    item.type.should.equal("buffer");
+    item.expires.should.equal(-1);
+    item.value.toString().should.equal(elt);
+  });
+
+  it('should set expire when specified', function () {
+    var elt = "foo";
+    var item = RedisItem.createBuffer(elt, 1000);
+
+    item.type.should.equal("buffer");
+    item.expires.should.equal(1000);
+    item.value.toString().should.equal(elt);
+  });
+});
+
+
 describe("Item.createSortedSet", function () {
   it('should create an empty sortedset', function () {
     var item = RedisItem.createSortedSet();

--- a/test/redis-mock.list.test.js
+++ b/test/redis-mock.list.test.js
@@ -1,10 +1,17 @@
-var redismock = require("../")
 var should = require("should")
 var events = require("events");
+var helpers = require("./helpers");
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
+
 
 describe("basic pushing/poping list", function () {
   var testKey = "myKey";
@@ -13,80 +20,66 @@ describe("basic pushing/poping list", function () {
   var testValue = 10;
 
   it("should not get any value from the end", function (done) {
-    var r = redismock.createClient();
     r.rpop(testKey, function (err, result) {
       should.not.exist(result);
-      r.end(true);
       done();
     });
   });
 
   it("should not get any value from the start", function (done) {
-    var r = redismock.createClient();
     r.lpop(testKey, function (err, result) {
       should.not.exist(result);
-      r.end(true);
       done();
     });
   });
 
   it("should push and pop the same element on the end", function (done) {
-    var r = redismock.createClient();
     r.rpush(testKey, testValue, function (err, result) {
       result.should.equal(1);
       r.rpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end(true);
         done();
       });
     });
   });
 
   it("should push and pop the same element on the start", function (done) {
-    var r = redismock.createClient();
     r.lpush(testKey, testValue, function (err, result) {
       result.should.equal(1);
       r.lpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end(true);
         done();
       });
     });
   });
 
   it("should check a single rpush array arg works", function (done) {
-    var r = redismock.createClient();
     r.rpush([testKey, testValue], function (err, result) {
       result.should.equal(1);
       r.rpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end(true);
         done();
       });
     });
   });
 
   it("should check a single lpush array arg works", function (done) {
-    var r = redismock.createClient();
     r.lpush([testKey, testValue], function (err, result) {
       result.should.equal(1);
       r.rpop(testKey, function (err, result) {
         result.should.equal(testValue + "");
-        r.end(true);
         done();
       });
     });
   });
 
   it("should be a queue", function (done) {
-    var r = redismock.createClient();
     r.lpush(testKey, testValue, function (err, result) {
       result.should.equal(1);
       r.lpush(testKey, testValue + 1, function (err, result) {
         result.should.equal(2);
         r.rpop(testKey, function (err, result) {
           result.should.equal(testValue + "");
-          r.end(true);
           done();
         });
       });
@@ -94,14 +87,12 @@ describe("basic pushing/poping list", function () {
   });
 
   it("should add a few elements", function (done) {
-    var r = redismock.createClient();
     var cb = function (err, result) {
       result.should.equal(testValues.length);
       r.lpop(testKey2, function (err, result) {
         result.should.equal(testValues[testValues.length - 1] + "");
         r.rpop(testKey2, function (err, result) {
           result.should.equal(testValues[0] + "");
-          r.end(true);
           done();
         });
       });
@@ -116,24 +107,19 @@ describe("llen", function () {
   var testValue = 10;
   it("should return 0", function (done) {
 
-    var r = redismock.createClient();
-
     r.llen(testKey, function (err, result) {
       result.should.equal(0);
-      r.end(true);
       done();
     });
   });
 
   it("should return 5 and evolve", function (done) {
-    var r = redismock.createClient();
     var cb = function (err, res) {
       r.llen(testKey, function (err, result) {
         result.should.equal(testValues.length);
         r.rpop(testKey, function (err, result) {
           r.llen(testKey, function (err, result) {
             result.should.equal(testValues.length - 1);
-            r.end(true);
             done();
           });
         });
@@ -152,8 +138,6 @@ describe("lindex", function () {
 
   it("getting index of non exisiting list", function (done) {
 
-    var r = redismock.createClient();
-
     r.lindex(keyUndefined, 0, function (err, result) {
 
       should.not.exist(result);
@@ -162,16 +146,12 @@ describe("lindex", function () {
 
         should.not.exist(result);
 
-        r.end(true);
-
         done();
       });
     });
   });
 
   it("getting positive indexes of exisiting list", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -187,8 +167,6 @@ describe("lindex", function () {
 
             result.should.equal(testValues[testValues.length - 1] + '');
 
-            r.end(true);
-
             done();
           });
         });
@@ -198,8 +176,6 @@ describe("lindex", function () {
   });
 
   it("getting negative indexes of exisiting list", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -214,8 +190,6 @@ describe("lindex", function () {
           r.lindex(testKey2, -testValues.length, function (err, result) {
 
             result.should.equal(testValues[0] + '');
-
-            r.end(true);
 
             done();
           });
@@ -234,16 +208,13 @@ describe("lrange", function () {
   var testValues = [1, 2, 3, 4, 5];
 
   it("getting a non-exisiting list", function (done) {
-    var r = redismock.createClient();
     r.lrange(keyU, 0, -1, function (err, result) {
       result.should.be.an.Array().and.have.lengthOf(0);
-      r.end(true);
       done();
     });
   });
 
   it("getting positive indexes of exisiting list", function (done) {
-    var r = redismock.createClient();
     var cb = function (err, result) {
       r.lrange(key1, 0, 1, function (err, result) {
         result.should.deepEqual(["1", "2"]);
@@ -253,7 +224,6 @@ describe("lrange", function () {
             result.should.deepEqual(["2", "3"]);
             r.lrange(key1, 2, 1, function (err, result) {
               result.should.be.an.Array().and.have.lengthOf(0);
-              r.end(true);
               done();
             });
           });
@@ -264,7 +234,6 @@ describe("lrange", function () {
   });
 
   it("getting negative indexes of exisiting list", function (done) {
-    var r = redismock.createClient();
     var cb = function (err, result) {
       r.lrange(key2, -2, -1, function (err, result) {
         result.should.deepEqual(["4", "5"]);
@@ -272,7 +241,6 @@ describe("lrange", function () {
           result.should.deepEqual(["1", "2"]);
           r.lrange(key2, -4, -5, function (err, result) {
             result.should.be.an.Array().and.have.lengthOf(0);
-            r.end(true);
             done();
           });
         });
@@ -282,7 +250,6 @@ describe("lrange", function () {
   });
 
   it("getting positive and negative indexes of exisiting list", function (done) {
-    var r = redismock.createClient();
     var cb = function (err, result) {
       r.lrange(key3, 0, -1, function (err, result) {
         result.should.deepEqual(["1", "2", "3", "4", "5"]);
@@ -290,7 +257,6 @@ describe("lrange", function () {
           result.should.deepEqual(["2", "3"]);
           r.lrange(key3, -4, 4, function (err, result) {
             result.should.deepEqual(["2", "3", "4", "5"]);
-            r.end(true);
             done();
           });
         });
@@ -312,21 +278,15 @@ describe("lset", function () {
 
   it("changing value of non exisiting list", function (done) {
 
-    var r = redismock.createClient();
-
     r.lset(keyUndefined, 0, 1, function (err, result) {
       err.message.should.equal("ERR no such key");
       should.not.exist(result);
-
-      r.end(true);
 
       done();
     });
   });
 
   it("setting impossible indexes", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -340,8 +300,6 @@ describe("lset", function () {
           err.message.should.equal("ERR index out of range");
           should.not.exist(result);
 
-          r.end(true);
-
           done();
         });
       });
@@ -350,8 +308,6 @@ describe("lset", function () {
   });
 
   it("changing value positive indexes from start index 0", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -363,8 +319,6 @@ describe("lset", function () {
 
           result.should.equal('3');
 
-          r.end(true);
-
           done();
         });
       });
@@ -373,8 +327,6 @@ describe("lset", function () {
   });
 
   it("changing value positive indexes from start index length-1", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -386,8 +338,6 @@ describe("lset", function () {
 
           result.should.equal('3');
 
-          r.end(true);
-
           done();
         });
       });
@@ -396,8 +346,6 @@ describe("lset", function () {
   });
 
   it("changing value negative indexes of exisiting list index -1", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -409,8 +357,6 @@ describe("lset", function () {
 
           result.should.equal('42');
 
-          r.end(true);
-
           done();
         });
       });
@@ -419,8 +365,6 @@ describe("lset", function () {
   });
 
   it("changing value negative indexes of exisiting list index -length", function (done) {
-
-    var r = redismock.createClient();
 
     var cb = function (err, result) {
 
@@ -431,8 +375,6 @@ describe("lset", function () {
         r.lindex(testKey4, 0, function (err, result) {
 
           result.should.equal('45');
-
-          r.end(true);
 
           done();
         });
@@ -448,8 +390,6 @@ describe("rpushx", function (argument) {
 
   it("tries to push on empty list", function (done) {
 
-    var r = redismock.createClient();
-
     r.rpushx(testKey, 3, function (err, result) {
 
       result.should.equal(0);
@@ -458,16 +398,12 @@ describe("rpushx", function (argument) {
 
         should.not.exist(result);
 
-        r.end(true);
-
         done();
       });
     });
   });
 
   it("tries to push on non empty list", function (done) {
-
-    var r = redismock.createClient();
 
     r.rpush(testKey, 3, function (err, result) {
 
@@ -478,8 +414,6 @@ describe("rpushx", function (argument) {
         r.lindex(testKey, 1, function (err, result) {
 
           result.should.equal('5');
-
-          r.end(true);
 
           done();
         });
@@ -493,8 +427,6 @@ describe("lpushx", function (argument) {
 
   it("tries to push on empty list", function (done) {
 
-    var r = redismock.createClient();
-
     r.lpushx(testKey, 3, function (err, result) {
 
       result.should.equal(0);
@@ -503,16 +435,12 @@ describe("lpushx", function (argument) {
 
         should.not.exist(result);
 
-        r.end(true);
-
         done();
       });
     });
   });
 
   it("tries to push on non empty list", function (done) {
-
-    var r = redismock.createClient();
 
     r.rpush(testKey, 3, function (err, result) {
 
@@ -524,8 +452,6 @@ describe("lpushx", function (argument) {
 
           result.should.equal('5');
 
-          r.end(true);
-
           done();
         });
       });
@@ -536,7 +462,6 @@ describe("lpushx", function (argument) {
 describe("brpop", function () {
 
   it("should block until the end of the timeout", function (done) {
-    var r = redismock.createClient();
     var time = false;
     r.brpop("foo", 1, function (err, result) {
       should.not.exist(result);
@@ -551,7 +476,6 @@ describe("brpop", function () {
   });
 
   it("should block until the end of the timeout even with multiple lists", function (done) {
-    var r = redismock.createClient();
     var time = false;
 
     r.brpop("foo", "ffo", 1, function (err, result) {
@@ -567,7 +491,6 @@ describe("brpop", function () {
   });
 
   it("should block with empty list", function (done) {
-    var r = redismock.createClient();
     r.rpush("foo2", "bar", function (err, result) {
 
       r.rpop("foo2", function (err, result) {
@@ -589,8 +512,7 @@ describe("brpop", function () {
   });
 
   it("should unblock when an element is added", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
 
     r.brpop("foo3", 5, function (err, result) {
@@ -610,8 +532,7 @@ describe("brpop", function () {
   });
 
   it("should unblock when an element is added to any list", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
     r.brpop("foo3", "foo4", 2, function (err, result) {
 
@@ -631,8 +552,7 @@ describe("brpop", function () {
   });
 
   it("push with multiple elements should be consired as one", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
     r.brpop("foo5", 2, function (err, result) {
       result[0].should.equal("foo5");
@@ -651,8 +571,7 @@ describe("brpop", function () {
   });
 
   it("should once it's unblocked it shouldn't be called again", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var called = 0;
     r.brpop("foo6", "foo7", 2, function (err, result) {
       called += 1;
@@ -671,7 +590,7 @@ describe("brpop", function () {
 
   /** This test needs for the connection to be able to be blocked
    it("should not work if we push with the connection which is blocked", function(done) {
-  var r = redismock.createClient();
+  var r = helpers.createClient();
   console.log("Waiting for pop...");
   r.brpop("foo6", "foo7", 1, function(err, result) {
 
@@ -692,7 +611,6 @@ describe("brpop", function () {
 describe("blpop", function () {
 
   it("should block until the end of the timeout", function (done) {
-    var r = redismock.createClient();
     var time = false;
 
     r.blpop("foo8", 1, function (err, result) {
@@ -710,7 +628,6 @@ describe("blpop", function () {
   });
 
   it("should block until the end of the timeout even with multiple lists", function (done) {
-    var r = redismock.createClient();
     var time = false;
     r.blpop("foo9", "ffo9", 1, function (err, result) {
       should.not.exist(result);
@@ -724,7 +641,6 @@ describe("blpop", function () {
   });
 
   it("should block with empty list too", function (done) {
-    var r = redismock.createClient();
     r.rpush("foo10", "bar", function (err, result) {
       r.rpop("foo10", function (err, result) {
         var time = false;
@@ -742,8 +658,7 @@ describe("blpop", function () {
   });
 
   it("should unblock when an element is added", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
 
     r.blpop("foo11", 1, function (err, result) {
@@ -763,8 +678,7 @@ describe("blpop", function () {
   });
 
   it("should unblock when an element is added to any list", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
 
     r.blpop("foo12", "foo13", 1, function (err, result) {
@@ -783,8 +697,7 @@ describe("blpop", function () {
   });
 
   it("push with multiple elements should be considered as one", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var time = false;
 
     r.blpop("foo14", 1, function (err, result) {
@@ -805,8 +718,7 @@ describe("blpop", function () {
   });
 
   it("should once it's unblocked it shouldn't be called again", function (done) {
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r2 = helpers.createClient();
     var called = 0;
     r.blpop("foo15", "foo16", 1, function (err, result) {
       called += 1;
@@ -834,23 +746,18 @@ describe("ltrim", function(argument) {
   var testValues = [1, 2, 3, 4, 5];
 
   it("does nothing for a non-existent list", function(done) {
-    var r = redismock.createClient();
-    
     r.ltrim(testKey, 0, 2, function(err, result) {
       result.should.equal('OK');
-      r.end(true);
       done();
     });
   });
 
   it("removes the whole list when start/end outside list length", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey, 5, 8, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey, 0, 4, function(err, result) {
           result.should.have.length(0);
-          r.end(true);
           done();
         });
       });
@@ -858,13 +765,11 @@ describe("ltrim", function(argument) {
   });
 
   it("removes the whole list when start > end", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey, 3, 2, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey, 0, 4, function(err, result) {
           result.should.have.length(0);
-          r.end(true);
           done();
         });
       });
@@ -872,14 +777,12 @@ describe("ltrim", function(argument) {
   });
 
   it("trims correctly for positive numbers", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey, 0, 2, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey, 0, 2, function(err, result) {
           // result.should.have.length(3);
           result.should.be.eql(["1", "2", "3"]);
-          r.end(true);
           done();
         });
       });
@@ -887,14 +790,12 @@ describe("ltrim", function(argument) {
   });
 
   it("trims correctly for negative numbers", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey, -2, -1, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey, 0, 2, function(err, result) {
           // result.should.have.length(3);
           result.should.be.eql(["4", "5"]);
-          r.end(true);
           done();
         });
       });
@@ -902,14 +803,12 @@ describe("ltrim", function(argument) {
   });
 
   it("trims correctly for end > len", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey2, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey2, 1, 5, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey2, 0, 8, function(err, result) {
           // result.should.have.length(3);
           result.should.be.eql(["2", "3", "4", "5"]);
-          r.end(true);
           done();
         });
       });
@@ -917,14 +816,12 @@ describe("ltrim", function(argument) {
   });
 
   it("trims correctly for one negativ number", function(done) {
-    var r = redismock.createClient();
     r.rpush(testKey3, 1, 2, 3, 4, 5, function(err, result) {
       r.ltrim(testKey3, 1, -1, function(err, result) {
         result.should.equal('OK');
         r.lrange(testKey3, 0, 5, function(err, result) {
           // result.should.have.length(3);
           result.should.be.eql(["2", "3", "4", "5"]);
-          r.end(true);
           done();
         });
       });

--- a/test/redis-mock.multi.js
+++ b/test/redis-mock.multi.js
@@ -1,14 +1,18 @@
-var redismock = require("../")
 var should = require("should")
 var events = require("events");
+var helpers = require("./helpers");
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe("multi()", function () {
-  var r = redismock.createClient();
-
   it("should exist", function () {
     should.exist(r.multi);
   });

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -1,16 +1,12 @@
-﻿var redismock = require("../");
-var should = require("should");
+﻿var should = require("should");
 var events = require("events");
-
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var helpers = require("./helpers");
 
 describe("publish and subscribe", function () {
 
   it("should subscribe and unsubscribe to a channel", function (done) {
 
-    var r = redismock.createClient();
+    var r = helpers.createClient();
 
     should.exist(r.subscribe);
     should.exist(r.unsubscribe);
@@ -36,7 +32,7 @@ describe("publish and subscribe", function () {
   });
 
   it("should psubscribe and punsubscribe to a channel", function (done) {
-    var r = redismock.createClient();
+    var r = helpers.createClient();
     var channelName = "testchannel";
 
     should.exist(r.psubscribe);
@@ -59,7 +55,7 @@ describe("publish and subscribe", function () {
     var channelName = "testchannel";
     var otherChannel = "otherchannel";
 
-    var r = redismock.createClient();
+    var r = helpers.createClient();
     r.subscribe(channelName);
 
     try {
@@ -77,7 +73,7 @@ describe("publish and subscribe", function () {
     var channelName = "testchannel";
     var otherChannel = "otherchannel";
 
-    var r = redismock.createClient();
+    var r = helpers.createClient();
     r.psubscribe(channelName);
 
     try {
@@ -96,8 +92,8 @@ describe("publish and subscribe", function () {
     var channelName = "testchannel";
     var otherChannel = "otherchannel";
 
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r = helpers.createClient();
+    var r2 = helpers.createClient();
     r.subscribe(channelName);
 
     r.on('message', function (ch, msg) {
@@ -121,8 +117,8 @@ describe("publish and subscribe", function () {
     var goodChannels = ["hllo*", "hello*", "heello*"];
     var badChannels = ["hllo", "hall", "hello*o"];
     var index = 0;
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
+    var r = helpers.createClient();
+    var r2 = helpers.createClient();
 
     r.psubscribe(pattern);
     r.on('pmessage', function (pattern, ch, msg) {
@@ -145,9 +141,9 @@ describe("publish and subscribe", function () {
     var channelName = "testchannel";
     var doneChannel = "donechannel";
 
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
-    var r3 = redismock.createClient();
+    var r = helpers.createClient();
+    var r2 = helpers.createClient();
+    var r3 = helpers.createClient();
 
     r.subscribe(channelName);
     r2.subscribe(channelName);
@@ -194,9 +190,9 @@ describe("publish and subscribe", function () {
     var channelName = "testchannel";
     var doneChannel = "donechannel";
 
-    var r = redismock.createClient();
-    var r2 = redismock.createClient();
-    var r3 = redismock.createClient();
+    var r = helpers.createClient();
+    var r2 = helpers.createClient();
+    var r3 = helpers.createClient();
 
     r.psubscribe(channelName);
     r2.psubscribe(channelName);

--- a/test/redis-mock.server.test.js
+++ b/test/redis-mock.server.test.js
@@ -1,15 +1,19 @@
-var redismock = require("../"),
-  should = require("should");
+var should = require("should");
+var helpers = require("./helpers");
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe("flushdb", function () {
 
   it("should clean database", function (done) {
-
-    var r = redismock.createClient();
 
     r.set("foo", "bar", function (err, result) {
       r.flushdb(function (err, result) {
@@ -19,10 +23,8 @@ describe("flushdb", function () {
 
           result.should.be.equal(0);
 
-          r.end(true);
           done();
-        })
-
+        });
 
       });
 
@@ -34,13 +36,9 @@ describe("flushdb", function () {
 
 describe("auth", function () {
   it("should always succeed and call back", function (done) {
-    var r = redismock.createClient();
-
     r.auth("secret", function (err, result) {
       result.should.equal('OK');
       done();
-      r.end(true); //Moved this after the done() call. For some reason, calling `end()` beforehand causes this test to fail.
     });
   });
 });
-

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -1,28 +1,31 @@
-var redismock = require('../')
-  , should = require('should');
+var should = require('should');
+var helpers = require('./helpers');
 
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe('sadd', function () {
 
   it('should add a member to the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', function (err, result) {
       result.should.eql(1);
 
       r.smembers('foo', function (err, result) {
         result.should.eql(['bar']);
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should add members to the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', 'qux', function (err, result) {
       result.should.eql(3);
 
@@ -33,14 +36,12 @@ describe('sadd', function () {
         result.should.containEql('baz');
         result.should.containEql('qux');
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should ignore members that are already a member of the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'bar', 'baz', function (err, result) {
       result.should.eql(2);
 
@@ -53,7 +54,6 @@ describe('sadd', function () {
           result.should.containEql('bar');
           result.should.containEql('baz');
 
-          r.end(true);
           done();
         });
       });
@@ -61,21 +61,18 @@ describe('sadd', function () {
   });
 
   it('should return error when the value stored at the key is not a set', function (done) {
-    var r = redismock.createClient();
 
     r.hset('foo', 'bar', 'baz', function (err, result) {
 
       r.sadd('foo', 'bar', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should support arguments without callback', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz');
     r.smembers('foo', function (err, result) {
       result.should.be.instanceof(Array);
@@ -83,7 +80,6 @@ describe('sadd', function () {
       result.should.containEql('bar');
       result.should.containEql('baz');
 
-      r.end(true);
       done();
     });
   });
@@ -93,7 +89,6 @@ describe('sadd', function () {
 describe('srem', function () {
 
   it('should remove a member from the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', 'qux', function (err, result) {
 
       r.srem('foo', 'bar', function (err, result) {
@@ -105,7 +100,6 @@ describe('srem', function () {
           result.should.containEql('baz');
           result.should.containEql('qux');
 
-          r.end(true);
           done();
         });
       });
@@ -113,7 +107,6 @@ describe('srem', function () {
   });
 
   it('should remove members from the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', 'qux', function (err, result) {
 
       r.srem('foo', 'bar', 'baz', function (err, result) {
@@ -124,7 +117,6 @@ describe('srem', function () {
           result.should.have.length(1);
           result.should.eql([ 'qux']);
 
-          r.end(true);
           done();
         });
       });
@@ -132,7 +124,6 @@ describe('srem', function () {
   });
 
   it('should ignore members that are not a member of the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', function (err, result) {
 
       r.srem('foo', 'bar', 'baz', function (err, result) {
@@ -141,7 +132,6 @@ describe('srem', function () {
         r.smembers('foo', function (err, result) {
           result.should.eql([]);
 
-          r.end(true);
           done();
         });
       });
@@ -149,41 +139,34 @@ describe('srem', function () {
   });
 
   it('should return 0 if the key does not exist', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', function (err, result) {
 
       r.srem('baz', 'qux', function (err, result) {
         result.should.eql(0);
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return error when the value stored at the key is not a set', function (done) {
-    var r = redismock.createClient();
-
     r.hset('foo', 'bar', 'baz', function (err, result) {
 
       r.srem('foo', 'bar', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should support arguments without callback', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.srem('foo', 'bar', 'baz');
       r.smembers('foo', function (err, result) {
         result.should.be.instanceof(Array);
         result.should.have.length(0);
 
-        r.end(true);
         done();
       });
     });
@@ -194,7 +177,6 @@ describe('srem', function () {
 describe('sismember', function () {
 
   it('should test if member exists', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo2', 'bar', 'baz', 'qux', function (err, result) {
       r.sismember('foo2', 'bar', function (err, result) {
         result.should.eql(1);
@@ -204,7 +186,6 @@ describe('sismember', function () {
   });
 
   it('should return 0 if member does not exist', function(done) {
-    var r = redismock.createClient();
     r.sadd('foo2', 'bar', 'baz', function (err, result) {
       r.sismember('foo2', 'qux', function(err, result) {
         result.should.eql(0);
@@ -214,7 +195,6 @@ describe('sismember', function () {
   });
 
   it('should return 0 if key is not set', function(done) {
-    var r = redismock.createClient();
     r.sismember('foo3', 'bar', function(err, result) {
       result.should.eql(0);
       done();
@@ -228,7 +208,6 @@ describe('sismember', function () {
 describe('smembers', function () {
 
   it('should return the empty array', function (done) {
-    var r = redismock.createClient();
     r.smembers("foo", function (err, result) {
       result.should.be.instanceof(Array);
       result.should.have.length(0);
@@ -237,7 +216,6 @@ describe('smembers', function () {
   });
 
   it('should return the empty array when all members removed from set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', function (err, result) {
       r.srem('foo', 'bar', function (err, result) {
         r.smembers('foo', function (err, result) {
@@ -253,33 +231,27 @@ describe('smembers', function () {
 describe('scard', function () {
 
   it('should return the number of elements', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.scard('foo', function (err, result) {
         result.should.eql(2);
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return 0 if key does not exist', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.scard('qux', function (err, result) {
         result.should.eql(0);
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return error when the value stored at the key is not a set', function (done) {
-    var r = redismock.createClient();
     r.hset('foo', 'bar', 'baz', function (err, result) {
       r.scard('foo', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
-        r.end(true);
         done();
       });
     });
@@ -290,24 +262,18 @@ describe('scard', function () {
 describe('srandmember', function () {
 
   it('should return a string from a set', function (done) {
-    var r = redismock.createClient();
-
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.srandmember('foo', function (err, result) {
         ['bar', 'baz'].should.containEql(result);
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return an array from a set if a length param is provided', function (done) {
-    var r = redismock.createClient();
-
     r.sadd('foo', 'bar', 'baz', 'bazing', function (err, result) {
       r.srandmember('foo', 2, function (err, result) {
         result.should.have.length(2);
-        r.end(true);
         done();
       });
     });
@@ -315,45 +281,34 @@ describe('srandmember', function () {
   });
 
   it('should return an array that does not exceed the size of the set', function (done) {
-    var r = redismock.createClient();
-
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.srandmember('foo', 3, function (err, result) {
         result.should.have.length(2);
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return null if the key does not exist and no length is provided', function (done) {
-    var r = redismock.createClient();
-
     r.sadd('foo', 'bar', 'baz', function (err, result) {
       r.srandmember('qux', function (err, result) {
         should(result).be.null();
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return an empty array if the key does not exist and a length is provided', function (done) {
-    var r = redismock.createClient();
-
     r.srandmember('foo', 2, function (err, result) {
       should(result).be.Array();
-      r.end(true);
       done();
     });
   });
 
   it('should return error when the value stored at the key is not a set', function (done) {
-    var r = redismock.createClient();
     r.hset('foo', 'bar', 'baz', function (err, result) {
       r.srandmember('foo', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
-        r.end(true);
         done();
       });
     });
@@ -364,7 +319,6 @@ describe('srandmember', function () {
 describe('smove', function () {
 
   it('should remove the element from the source if it exists', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', 'qux', function (err, result) {
 
       r.smove('foo', 'bar', 'baz', function (err, result) {
@@ -375,7 +329,6 @@ describe('smove', function () {
           result.should.have.length(1);
           result.should.containEql('qux');
 
-          r.end(true);
           done();
         });
       });
@@ -383,7 +336,6 @@ describe('smove', function () {
   });
 
   it('should add the element to the destination if it exists', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', 'qux', function (err, result) {
       r.sadd('bar', 'qux', function (err, result) {
 
@@ -396,7 +348,6 @@ describe('smove', function () {
             result.should.containEql('qux');
             result.should.containEql('baz');
 
-            r.end(true);
             done();
           });
         });
@@ -405,7 +356,6 @@ describe('smove', function () {
   });
 
   it('should add the element to the destination if it does not exist', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', 'qux', function (err, result) {
 
       r.smove('foo', 'bar', 'baz', function (err, result) {
@@ -416,7 +366,6 @@ describe('smove', function () {
           result.should.have.length(1);
           result.should.containEql('baz');
 
-          r.end(true);
           done();
         });
       });
@@ -424,7 +373,6 @@ describe('smove', function () {
   });
 
   it('should do nothing if the element is not a member of source', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', function (err, result) {
       r.sadd('bar', 'quux', function(err, result) {
 
@@ -440,7 +388,6 @@ describe('smove', function () {
               result.should.be.instanceof(Array);
               result.should.have.length(1);
               result.should.containEql('baz');
-              r.end(true);
               done();
             });
           });
@@ -450,27 +397,23 @@ describe('smove', function () {
   });
 
   it('should return error when the value stored at the source key is not a set', function (done) {
-    var r = redismock.createClient();
     r.hset('foo', 'baz', 'qux', function (err, result) {
 
       r.smove('foo', 'bar', 'baz', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-        r.end(true);
         done();
       });
     });
   });
 
   it('should return error when the value stored at the destination key is not a set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', function (err, result) {
       r.hset('bar', 'baz', 'qux', function (err, result) {
 
         r.smove('foo', 'bar', 'baz', function (err, result) {
           err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
 
-          r.end(true);
           done();
         });
 
@@ -479,7 +422,6 @@ describe('smove', function () {
   });
 
   it('should ignore members that are already a member of the set', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', function (err, result) {
       r.sadd('bar', 'baz', function (err, result) {
 
@@ -495,7 +437,6 @@ describe('smove', function () {
               result.should.have.length(1);
               result.should.containEql('baz');
 
-              r.end(true);
               done();
             });
           });
@@ -505,7 +446,6 @@ describe('smove', function () {
   });
 
   it('should support arguments without callback', function (done) {
-    var r = redismock.createClient();
     r.sadd('foo', 'baz', function(err, result) {
 
       r.smove('foo', 'bar', 'baz');
@@ -518,7 +458,6 @@ describe('smove', function () {
           result.should.have.length(1);
           result.should.containEql('baz');
 
-          r.end(true);
           done();
         });
       });

--- a/test/redis-mock.sortedset.test.js
+++ b/test/redis-mock.sortedset.test.js
@@ -1,9 +1,5 @@
-var redismock = require("../");
 var should = require("should");
-
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var helpers = require("./helpers");
 
 /**
   *** NOT IMPLEMENTED ***
@@ -15,6 +11,16 @@ if (process.env['VALID_TESTS']) {
   ZUNIONSTORE destination numkeys key [key ...] [WEIGHTS weight [weight ...]] [AGGREGATE SUM|MIN|MAX]
   ZSCAN key cursor [MATCH pattern] [COUNT count]
 */
+
+var r;
+
+beforeEach(function () {
+  r = helpers.createClient();
+});
+
+afterEach(function () {
+  r.flushall();
+});
 
 describe("zadd", function () {
   var testKey1 = "zaddKey1";
@@ -32,7 +38,6 @@ describe("zadd", function () {
   var aLen = args.length;
   var mLen = aLen / 2;
   it("should add scores and members", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       // should only add new members
@@ -72,9 +77,8 @@ describe("zcard", function () {
   var testMember1 = JSON.stringify({'a': 'b'});
   var testScore2 = 2;
   var testMember2 = '2';
-  it("should add scores and members", function (done) {
-    var r = redismock.createClient();
 
+  it("should add scores and members", function (done) {
     r.zadd(testKey1, testScore1, testMember1, testScore2, testMember2,
       function(err, result) {
         result.should.equal(2);
@@ -104,7 +108,6 @@ describe("zcount", function () {
   var mLen = aLen / 2;
 
   it("should return the inclusive min & max count", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
 
@@ -123,7 +126,6 @@ describe("zincrby", function () {
   var testKey2 = "zincrbyKey2";
 
   it("should add and increment a member", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1,  1, 'm1'], function(err, result) {
       result.should.equal(1);
       r.zincrby([testKey1, 5, 'm1'], function(err, result) {
@@ -134,7 +136,6 @@ describe("zincrby", function () {
   });
 
   it("should increment a non-existing member", function (done) {
-    var r = redismock.createClient();
     r.zincrby([testKey2, '5', 'm1'], function(err, result) {
       should(result).equal('5');
 
@@ -168,7 +169,6 @@ describe("zrange", function () {
   var mLen = aLen / 2;
 
   it("should return everything withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrange([testKey1, '0', '-1', 'withscores'], function(err, result) {
@@ -181,7 +181,6 @@ describe("zrange", function () {
   });
 
   it("should return the inclusive start & stop withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey2].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrange([testKey2, '1', '5', 'withscores'], function(err, result) {
@@ -195,7 +194,6 @@ describe("zrange", function () {
   });
 
   it("should return everything without scores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey3].concat(args), function(err, result) {
       r.zrange([testKey3, '0', '-1'], function(err, result) {
         should(result[0]).equal('m1');
@@ -207,7 +205,6 @@ describe("zrange", function () {
   });
 
   it("should return the inclusive start & stop without scores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey4].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrange([testKey4, '1', '5'], function(err, result) {
@@ -220,7 +217,6 @@ describe("zrange", function () {
   });
 
   it("should return last two members", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey5].concat(args), function(err, result) {
       r.zrange([testKey5, '-2', '-1'], function(err, result) {
         should(result[0]).equal('m2');
@@ -255,7 +251,6 @@ describe("zrangebyscore", function () {
   var mLen = aLen / 2;
 
   it("should return the inclusive min & max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrangebyscore([testKey1, '0', '5', 'withscores'], function(err, result) {
@@ -266,7 +261,6 @@ describe("zrangebyscore", function () {
   });
 
   it("should return the inclusive min and max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey2].concat(args), function(err, result) {
       r.zrangebyscore([testKey2, '0', '(3', 'withscores'], function(err, result) {
         should(result.length).equal(7 * 2);
@@ -277,7 +271,6 @@ describe("zrangebyscore", function () {
   });
 
  it("should return the min and inclusive max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey3].concat(args), function(err, result) {
       r.zrangebyscore([testKey3, '(1.5', '3', 'withscores'], function(err, result) {
         should(result.length).equal(2 * 2);
@@ -287,7 +280,6 @@ describe("zrangebyscore", function () {
   });
 
   it("should return the min and max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey4].concat(args), function(err, result) {
       r.zrangebyscore([testKey4, '(1', '(2', 'withscores'], function(err, result) {
         should(result.length).equal(5 * 2);
@@ -297,7 +289,6 @@ describe("zrangebyscore", function () {
   });
 
   it("should return the inclusive min & max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey5].concat(args), function(err, result) {
       r.zrangebyscore([testKey5, '0', '5', 'withscores', 'limit', '1', '3'], function(err, result) {
         should(result.length).equal(6);
@@ -307,7 +298,6 @@ describe("zrangebyscore", function () {
   });
 
   it("should return the inclusive -inf & +inf range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey6, '-1', 'm-1'].concat(args), function(err, result) {
       r.zrangebyscore([testKey6, '-inf', '+inf', 'withscores'], function(err, result) {
         should(result[0]).equal('m-1');
@@ -321,7 +311,6 @@ describe("zrangebyscore", function () {
 });
 
 describe("zrank", function () {
-
   var testKey1 = "zrankKey1";
   var args = [
     1, 'm1',
@@ -334,7 +323,6 @@ describe("zrank", function () {
     1.5, 'm1.5'
   ];
   it("should return the rank for a member", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       r.zrank(testKey1, 'm1.1', function(err, result) {
         result.should.equal(1);
@@ -343,7 +331,6 @@ describe("zrank", function () {
     });
   });
   it("should return a null rank for a missing member", function (done) {
-    var r = redismock.createClient();
     r.zrank(testKey1, 'm999', function(err, result) {
       should(result).equal(null);
       done();
@@ -364,7 +351,6 @@ describe("zrem", function () {
     1.5, 'm1.5'
   ];
   it("should add and remove members", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
         r.zrem([testKey1, 'm1', 'm2'], function(err, result) {
           result.should.equal(2);
@@ -390,7 +376,6 @@ describe("zremrangebyrank", function () {
     1.5, 'm1.5'
   ];
   it("should add and remove members by rank", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
         r.zremrangebyrank([testKey1, '0', '1'], function(err, result) {
           result.should.equal(2);
@@ -415,7 +400,6 @@ describe("zremrangebyscore", function () {
     1.5, 'm1.5'
   ];
   it("should add and remove members by rank", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
         r.zremrangebyscore([testKey1, '1.1', '1.5'], function(err, result) {
           result.should.equal(5);
@@ -448,7 +432,6 @@ describe("zrevrange", function () {
   var mLen = aLen / 2;
 
   it("should return everything withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey1, '0', '-1', 'withscores'], function(err, result) {
@@ -463,7 +446,6 @@ describe("zrevrange", function () {
   });
 
   it("should return the inclusive start & stop withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey2].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey2, '1', '5', 'withscores'], function(err, result) {
@@ -478,7 +460,6 @@ describe("zrevrange", function () {
   });
 
   it("should return everything without scores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey3].concat(args), function(err, result) {
       r.zrevrange([testKey3, '0', '-1'], function(err, result) {
         should(result[0]).equal('m11');
@@ -491,7 +472,6 @@ describe("zrevrange", function () {
   });
 
   it("should return the inclusive start & stop without scores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey4].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrange([testKey4, '1', '5'], function(err, result) {
@@ -504,7 +484,6 @@ describe("zrevrange", function () {
   });
 
   it("should return last two members", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey5].concat(args), function(err, result) {
       r.zrevrange([testKey5, '-2', '-1'], function(err, result) {
         should(result[0]).equal('m1.1');
@@ -540,7 +519,6 @@ describe("zrevrangebyscore", function () {
   var mLen = aLen / 2;
 
   it("should return the inclusive min & max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       result.should.equal(mLen);
       r.zrevrangebyscore([testKey1, '5', '0', 'withscores'], function(err, result) {
@@ -553,7 +531,6 @@ describe("zrevrangebyscore", function () {
   });
 
   it("should return the inclusive min and max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey2].concat(args), function(err, result) {
       r.zrevrangebyscore([testKey2, '(3', '0', 'withscores'], function(err, result) {
         should(result[0]).equal('m2');
@@ -566,7 +543,6 @@ describe("zrevrangebyscore", function () {
   });
 
  it("should return the min and inclusive max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey3].concat(args), function(err, result) {
       r.zrevrangebyscore([testKey3, '3', '(1.5', 'withscores'], function(err, result) {
         should(result[0]).equal('m3');
@@ -578,7 +554,6 @@ describe("zrevrangebyscore", function () {
   });
 
   it("should return the min and max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey4].concat(args), function(err, result) {
       r.zrevrangebyscore([testKey4, '(2', '(1', 'withscores'], function(err, result) {
         should(result[0]).equal('m1.5');
@@ -590,7 +565,6 @@ describe("zrevrangebyscore", function () {
   });
 
   it("should return the inclusive min & max range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey5].concat(args), function(err, result) {
       r.zrevrangebyscore([testKey5, '5', '0', 'withscores', 'limit', '1', '3'], function(err, result) {
         should(result.length).equal(6);
@@ -600,7 +574,6 @@ describe("zrevrangebyscore", function () {
   });
 
   it("should return the inclusive -inf & +inf range withscores", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey6, '-1', 'm-1'].concat(args), function(err, result) {
       r.zrevrangebyscore([testKey6, '+inf', '-inf', 'withscores'], function(err, result) {
         should(result[0]).equal('m3');
@@ -628,7 +601,6 @@ describe("zrevrank", function () {
     1.5, 'm1.5'
   ];
   it("should return the rank for a member", function (done) {
-    var r = redismock.createClient();
     r.zadd([testKey1].concat(args), function(err, result) {
       r.zrevrank(testKey1, 'm2', function(err, result) {
         result.should.equal(1);
@@ -637,7 +609,6 @@ describe("zrevrank", function () {
     });
   });
   it("should return a null rank for a missing member", function (done) {
-    var r = redismock.createClient();
     r.zrevrank(testKey1, 'm999', function(err, result) {
       should(result).equal(null);
       done();
@@ -650,7 +621,6 @@ describe("zscore", function () {
   var testScore1 = 100.00;
   var testMember1 = JSON.stringify({'a': 'b'});
   it("should add and return member score", function (done) {
-    var r = redismock.createClient();
     r.zadd(testKey1, testScore1, testMember1, function(err, result) {
       result.should.equal(1);
 
@@ -666,7 +636,6 @@ describe("sortedset multi commands", function () {
   var testKey1 = "sortedsetmultiKey1";
 
   it("should handle multi exec", function (done) {
-    var r = redismock.createClient();
     var multi = r.multi();
     // smoke test that some of these work
     multi.zadd([testKey1, '1', 'm1'], function(err, result) {

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -1,15 +1,11 @@
-var redismock = require("../"),
-  should = require("should"),
-  events = require("events");
-
-
-if (process.env['VALID_TESTS']) {
-  redismock = require('redis');
-}
+var should = require("should");
+var events = require("events");
+var helpers = require("./helpers");
+var redismock = require("../");
 
 // Clean the db after each test
 afterEach(function (done) {
-  r = redismock.createClient();
+  r = helpers.createClient();
   r.flushdb(function () {
     r.end(true);
     done();


### PR DESCRIPTION
Add support for setting/getting Buffers for basic string operations. This is compatible with node_redis where `detect_buffers` is set to true.

* Add `RedisBuffer` item type.
* Allow buffers for `get`, `set`, `getset`, `mget`, `mset`.
* If given a buffer in `set`, it is sent to Redis untouched (no call to `toString()`).
* If given a buffer for the key in `get`, it returns a buffer for the value. If given a string, it returns a string. This is the same regardless of the type of value originally stored in the cache. (This matches the behavior of node_redis.)
* Refactor `mget` to use `get` for consistent behavior.
* Refactor  tests to use `beforeEach` and `afterEach` for proper setup and teardown of cache.
* Add ability to set the redis instance to use when running `make check-tests` by setting `REDIS_URL` environment variable.