### PR TITLE
Fix pubsub.unsubscribe to unsubscribe all on empty args

### DIFF
--- a/lib/pubsub.js
+++ b/lib/pubsub.js
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Subscribe
  *
  * TODO: Verify how multiple channel subscription works in actual Redis
@@ -60,24 +60,24 @@ exports.unsubscribe = function () {
   var self = this
     , subcriptions = arguments;
 
-  // TODO: Unsubscribe from ALL channels
   if (!arguments.length) {
-    subcriptions = self.subscriptions.map(function (__, subscription) {
+    subcriptions = Object.keys(self.subscriptions).map(function (subscription) {
       return subscription;
     })
   }
 
   for (var i = 0; i < subcriptions.length; i++) {
 
-    if ('string' == typeof arguments[i]) {
+    if ('string' == typeof subcriptions[i]) {
 
       // Event on next tick to emulate an actual server call
-      var channelName = arguments[i];
-      process.nextTick(function () {
-        self.subscriptions[channelName] = false;
-        delete self.subscriptions[channelName];
-        self.emit('unsubscribe', channelName);
-      });
+      var channelName = subcriptions[i];
+      process.nextTick((function(channelName) {
+        return function () {
+          self.subscriptions[channelName] = false;
+          delete self.subscriptions[channelName];
+          self.emit('unsubscribe', channelName);
+        } })(channelName));
     }
   }
 

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -31,6 +31,38 @@ describe("publish and subscribe", function () {
     r.subscribe(channelName);
   });
 
+  it("should unsubscribe to all channels if no arguments are given", function (done) {
+
+    var r = helpers.createClient();
+
+    should.exist(r.subscribe);
+    should.exist(r.unsubscribe);
+
+    var channelNames = ["firstchannel", "secondchannel"];
+    var channelsSubscribed = 0;
+    var channelsUnsubscribed = 0;
+
+    r.on("subscribe", function (ch) {
+      channelsSubscribed++;
+
+      if (channelsSubscribed == channelNames.length) {
+        r.unsubscribe();
+      }
+    });
+
+    r.on("unsubscribe", function (ch) {
+      channelsUnsubscribed++;
+      if (channelsUnsubscribed == channelNames.length) {
+        r.subscriptions.should.be.an.Object().and.be.empty();
+        r.end(true);
+        done();
+      }
+    });
+
+    r.subscribe(channelNames[0]);
+    r.subscribe(channelNames[1]);
+  });
+
   it("should psubscribe and punsubscribe to a channel", function (done) {
     var r = helpers.createClient();
     var channelName = "testchannel";


### PR DESCRIPTION
Calling unsubscribe without any `channelName` caused the app to crash as `self.subscriptions` is an object and not an array.
This should also solve an issue with only the first channel would be unsubscribed because of scope issue.