### PR TITLE
Fixed: incr, incrby and incrbyfloat mustn't clear expires

### DIFF
--- a/lib/strings.js
+++ b/lib/strings.js
@@ -228,7 +228,7 @@ exports.incr = function (mockInstance, key, callback) {
 
   } else if (_isInteger(mockInstance.storage[key].value)) {
     var number = parseInt(mockInstance.storage[key].value, 10) + 1;
-    exports.set(mockInstance, key, number);
+    mockInstance.storage[key].value = number.toString();
     mockInstance._callCallback(callback, null, number);
 
   } else {
@@ -259,7 +259,7 @@ exports.incrby = function (mockInstance, key, value, callback) {
 
   } else if (_isInteger(mockInstance.storage[key].value)) {
     var number = parseInt(mockInstance.storage[key].value, 10) + value;
-    exports.set(mockInstance, key, number);
+    mockInstance.storage[key].value = number.toString();
     mockInstance._callCallback(callback, null, number);
 
   } else {
@@ -288,7 +288,7 @@ exports.incrbyfloat = function (mockInstance, key, value, callback) {
 
   } else if (_isFloat(mockInstance.storage[key].value) && _isFloat(value)) {
     var number = parseFloat(mockInstance.storage[key].value, 10) + parseFloat(value, 10);
-    exports.set(mockInstance, key, number.toString());
+    mockInstance.storage[key].value = number.toString();
     mockInstance._callCallback(callback, null, number.toString());
 
   } else {

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -520,6 +520,22 @@ describe("incr", function () {
     });
   });
 
+  it("should keep expires if it is set", function (done) {
+
+    r.set("foo", 10, "EX", 5, function (err, result) {
+
+      r.incr("foo", function (err, result) {
+
+        r.pttl("foo", function (err, result) {
+
+          (result === -1).should.be.false();
+
+          done();
+        });
+      });
+    });
+  });
+
   it("should return error if the key holds the wrong kind of value.", function (done) {
 
     r.hset("foo", "bar", "baz", function (err, result) {
@@ -582,6 +598,22 @@ describe("incrby", function () {
     });
   });
 
+  it("should keep expires if it is set", function (done) {
+
+    r.set("foo", 10, "EX", 5, function (err, result) {
+
+      r.incrby("foo", 1, function (err, result) {
+
+        r.pttl("foo", function (err, result) {
+
+          (result === -1).should.be.false();
+
+          done();
+        });
+      });
+    });
+  });
+
   it("should return error if the key holds the wrong kind of value.", function (done) {
 
     r.hset("foo", "bar", "baz", function (err, result) {
@@ -638,6 +670,22 @@ describe("incrbyfloat", function () {
         result.should.eql("1.5");
 
         done();
+      });
+    });
+  });
+
+  it("should keep expires if it is set", function (done) {
+
+    r.set("foo", 10, "EX", 5, function (err, result) {
+
+      r.incrbyfloat("foo", "1.5", function (err, result) {
+
+        r.pttl("foo", function (err, result) {
+
+          (result === -1).should.be.false();
+
+          done();
+        });
       });
     });
   });


### PR DESCRIPTION
incr functions mustn't not clear expires https://redis.io/commands/expire