### PR TITLE
Add type command

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ Currently implemented are the following redis commands:
 * keys
 * scan
 * exists
+* type
 * expire
 * ttl
 * incr

--- a/lib/item.js
+++ b/lib/item.js
@@ -87,7 +87,7 @@ util.inherits(RedisSet, RedisItem);
  * Constructor of a sortedset
  */
 var RedisSortedSet = function () {
-  RedisItem.call(this, "sortedset");
+  RedisItem.call(this, "zset");
   this.value = {};
 }
 util.inherits(RedisSortedSet, RedisItem);

--- a/lib/keys.js
+++ b/lib/keys.js
@@ -34,6 +34,16 @@ exports.exists = function (mockInstance, key, callback) {
   mockInstance._callCallback(callback, null, result);
 }
 
+exports.type = function(mockInstance, key, callback) {
+  var type = "none";
+
+  if (key in mockInstance.storage) {
+    type = mockInstance.storage[key].type;
+  }
+
+  mockInstance._callCallback(callback, null, type);
+};
+
 /**
  * Expire
  */

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -214,6 +214,10 @@ RedisClient.prototype.exists = RedisClient.prototype.EXISTS = function (key, cal
   keyfunctions.exists.call(this, MockInstance, key, callback);
 };
 
+RedisClient.prototype.type = RedisClient.prototype.TYPE = function(key, callback) {
+  keyfunctions.type.call(this, MockInstance, key, callback);
+}
+
 RedisClient.prototype.expire = RedisClient.prototype.EXPIRE = function (key, seconds, callback) {
 
   keyfunctions.expire.call(this, MockInstance, key, seconds, callback);

--- a/lib/sortedset.js
+++ b/lib/sortedset.js
@@ -34,7 +34,7 @@ var MIN_SCORE_VALUE = -MAX_SCORE_VALUE;
 var mockCallback = helpers.mockCallback;
 
 var validKeyType = function(mockInstance, key, callback) {
-  return helpers.validKeyType(mockInstance, key, 'sortedset', callback)
+  return helpers.validKeyType(mockInstance, key, 'zset', callback)
 }
 
 var initKey = function(mockInstance, key) {

--- a/test/redis-mock.item.test.js
+++ b/test/redis-mock.item.test.js
@@ -83,7 +83,7 @@ describe("Item.createSortedSet", function () {
   it('should create an empty sortedset', function () {
     var item = RedisItem.createSortedSet();
 
-    item.type.should.equal("sortedset");
+    item.type.should.equal("zset");
     item.expires.should.equal(-1);
     item.value.should.eql({});
   });

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -121,10 +121,10 @@ describe("type", function() {
     });
   });
 
-  it('should return type "sortedset" for key that exists with zset value', function (done) {
+  it('should return type "zset" for key that exists with zset value', function (done) {
     r.zadd(["testKey",  1, 'm1'], function(err, result) {
       r.type("testKey", function(err, result) {
-        result.should.equal("sortedset");
+        result.should.equal("zset");
 
         done();
       });

--- a/test/redis-mock.keys.test.js
+++ b/test/redis-mock.keys.test.js
@@ -82,6 +82,66 @@ describe("exists", function () {
 
 });
 
+describe("type", function() {
+  it('should return "none" for non existent keys', function(done) {
+    r.type("testKey", function(err, result) {
+        result.should.equal("none");
+
+        done();
+    });
+  });
+
+  it('should return type "string" for key that exists with string value', function(done) {
+    r.set("testKey", "testValue", function(err, result) {
+      r.type("testKey", function(err, result) {
+        result.should.equal("string");
+
+        done();
+      });
+    });
+  });
+
+  it('should return type "list" for key that exists with list value', function(done) {
+    r.lpush("testValue", 1, function (err, result) {
+      r.type("testValue", function(err, result) {
+        result.should.equal("list");
+
+        done();
+      });
+    });
+  });
+
+  it('should return type "set" for key that exists with set value', function (done) {
+    r.sadd('testKey', 'testValue', function (err, result) {
+      r.type("testKey", function(err, result) {
+        result.should.equal("set");
+
+        done();
+      });
+    });
+  });
+
+  it('should return type "sortedset" for key that exists with zset value', function (done) {
+    r.zadd(["testKey",  1, 'm1'], function(err, result) {
+      r.type("testKey", function(err, result) {
+        result.should.equal("sortedset");
+
+        done();
+      });
+    });
+  });
+
+  it('should return type "hash" for key that exists with hash value', function (done) {
+    r.hset("testHash", "testKey", "test", function (err, result) {
+      r.type("testHash", function(err, result) {
+        result.should.equal("hash");
+
+        done();
+      });
+    });
+  });
+});
+
 describe("expire", function () {
 
   it("should return 0 for non-existing key", function (done) {


### PR DESCRIPTION
Adds the `type` command.

This PR also updates the type of sorted set from `sortedset` to `zset`. This makes sure that when running the `TYPE` command on a sorted set you will receive the expected return value (as per the [docs](https://redis.io/commands/type)).

Let me know if there's anything I missed / more that I can do!