### PR TITLE
zscore function should return null and not undefined for non-existent member

### DIFF
--- a/lib/sortedset.js
+++ b/lib/sortedset.js
@@ -219,7 +219,7 @@ var getRangeByScore = function(
     min = MAX_SCORE_VALUE;
   }
   if (max.toString() === '-inf') {
-    max = MIN_SCORE_INTEGER;
+    max = MIN_SCORE_VALUE;
   }
 
   // convert to string so we can test for inclusive range

--- a/lib/sortedset.js
+++ b/lib/sortedset.js
@@ -595,5 +595,5 @@ exports.zscore = function(mockInstance, key, member, callback) {
   }
   initKey(mockInstance, key);
   var score = mockInstance.storage[key].value[Item._stringify(member)];
-  mockInstance._callCallback(callback, null, score);
+  mockInstance._callCallback(callback, null, (score === undefined ? null : score));
 }

--- a/test/redis-mock.sortedset.test.js
+++ b/test/redis-mock.sortedset.test.js
@@ -617,6 +617,8 @@ describe("zrevrank", function () {
 });
 
 describe("zscore", function () {
+  var nonExistentKey = '$#$#@#%%';
+  var nonExistentMember = '@#@##$';
   var testKey1 = "zscoreKey1";
   var testScore1 = 100.00;
   var testMember1 = JSON.stringify({'a': 'b'});
@@ -626,6 +628,16 @@ describe("zscore", function () {
 
       r.zscore([testKey1, testMember1], function(err, result) {
         result.should.equal(String(100.00));
+        done();
+      });
+    });
+  });
+  it("should return null on non existent key and/or member", function (done) {
+    r.zscore([nonExistentKey, nonExistentKey], function(err, result) {
+      should(result).be.null();
+
+      r.zscore([testKey1, nonExistentKey], function(err, result) {
+        should(result).be.null();
         done();
       });
     });


### PR DESCRIPTION
The node redis library states
> If the key is missing, reply will be null. Only if the Redis Command Reference states something else it will not be null.

It's not just with the key, but when the member is also missing, it returns undefined. I have fixed it and included a test.

Also while I was at it, I saw a typo on negative infinity value. Please check