### PR TITLE
Fixed callback parameters on 'pmessage' event

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -120,7 +120,7 @@ function RedisClient(stream, options) {
 
     Object.keys(self.psubscriptions).some(function(key) {
       if(self.psubscriptions[key].test(ch)) {
-        self.emit('pmessage', key, key, msg);
+        self.emit('pmessage', key, ch, msg);
         return true;
       }
       return false;

--- a/test/redis-mock.pubsub.test.js
+++ b/test/redis-mock.pubsub.test.js
@@ -147,14 +147,15 @@ describe("publish and subscribe", function () {
     var pattern = "h*llo\\*";
     var goodChannels = ["hllo*", "hello*", "heello*"];
     var badChannels = ["hllo", "hall", "hello*o"];
+    var messages = ["msg1", "msg2", "msg3"]
     var index = 0;
     var r = helpers.createClient();
     var r2 = helpers.createClient();
 
     r.psubscribe(pattern);
     r.on('pmessage', function (pattern, ch, msg) {
-      ch.should.equal(ch);
-      msg.should.equal(goodChannels[index]);
+      ch.should.equal(goodChannels[index]);
+      msg.should.equal(messages[index]);
       index++;
       if(index === goodChannels.length) {
         r.punsubscribe(pattern);
@@ -163,8 +164,13 @@ describe("publish and subscribe", function () {
       }
     });
 
-    badChannels.forEach(function (channelName) { r2.publish(channelName, channelName); });
-    goodChannels.forEach(function (channelName) { r2.publish(channelName, channelName); });
+    badChannels.forEach(function (channelName, i) {
+      r2.publish(channelName, messages[i]);
+    });
+
+    goodChannels.forEach(function (channelName, i) {
+      r2.publish(channelName, messages[i]);
+    });
   });
 
   it("should support multiple subscribers", function (done) {


### PR DESCRIPTION
According to official documentation (https://github.com/NodeRedis/node_redis#pmessage-pattern-channel-message), the callback function in `.on('pmessage', callback)` should be called with the channel as second argument but was being called with the pattern.