### PR TITLE
`duplicate()` missing function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Currently implemented are the following redis commands:
 
 ### General
 * createClient
+* duplicate
 * auth
 * end
 * multi

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -174,6 +174,17 @@ var end = RedisClient.prototype.end = function () {
 }
 
 /**
+ * Duplicate
+ */
+RedisClient.prototype.duplicate = function (_options, callback) {
+  if (typeof callback !== 'undefined') {
+    return callback(null, new RedisClient());
+  } else {
+    return new RedisClient();
+  }
+};
+
+/**
  * Quit
  */
 RedisClient.prototype.quit = end;

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -27,6 +27,43 @@ describe("redis-mock", function () {
 
   });
 
+  it("should create a new RedisClient with duplicate(), not using callback", function() {
+    should.exist(redismock.createClient);
+    var r = redismock.createClient();
+    should.exist(r);
+    r.should.be.an.instanceof(redismock.RedisClient);
+    r.should.be.an.instanceof(events.EventEmitter);
+
+    var r2 = r.duplicate();
+    should.exist(r2);
+    r2.should.be.an.instanceof(redismock.RedisClient);
+    r2.should.be.an.instanceof(events.EventEmitter);
+
+    r.end(true);
+    r2.end(true);
+  });
+
+  it("should create a new RedisClient with duplicate(), using the callback", function(done) {
+    should.exist(redismock.createClient);
+    var r = redismock.createClient();
+    should.exist(r);
+    r.should.be.an.instanceof(redismock.RedisClient);
+    r.should.be.an.instanceof(events.EventEmitter);
+
+    r.duplicate(null, function (err, r2) {
+      if (err) {
+        should.fail(err, null, "Expected null error.", "");
+      }
+      should.exist(r2);
+      r2.should.be.an.instanceof(redismock.RedisClient);
+      r2.should.be.an.instanceof(events.EventEmitter);
+
+      r.end(true);
+      r2.end(true);
+      done();
+    });
+  });
+
   it("should emit ready and connected when creating client", function (done) {
 
     var r = redismock.createClient();


### PR DESCRIPTION
This adds a mock for the `duplicate` method.

#63 
