### PR TITLE
Add connected prop

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -107,6 +107,7 @@ function RedisClient(stream, options) {
 
   var self = this;
 
+  this.connected = false;
   this.pub_sub_mode = false;
 
 
@@ -133,10 +134,12 @@ function RedisClient(stream, options) {
   this.subscriptions = {};
   this.psubscriptions = {};
 
+
   process.nextTick(function () {
 
     self.emit("ready");
     self.emit("connect");
+    self.connected = true;
 
   });
 }

--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -136,11 +136,9 @@ function RedisClient(stream, options) {
 
 
   process.nextTick(function () {
-
-    self.emit("ready");
-    self.emit("connect");
     self.connected = true;
-
+    self.emit("connect");
+    self.emit("ready");
   });
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-mock",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-mock",
-  "version": "0.31.0",
+  "version": "0.32.0",
   "description": "Redis client mock object for unit testing",
   "author": "Kristian Faeldt <kristian.faeldt@gmail.com>",
   "main": "./lib/redis-mock",

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -99,6 +99,19 @@ describe("redis-mock", function () {
 
   });
 
+  it("should have '.connected' boolean property that reflects 'ready' state", function (done) {
+
+    var r = redismock.createClient();
+
+    r.connected.should.be.an.instanceof(Boolean);
+    r.connected.should.eql(false);
+    r.on("ready", function () {
+      r.connected.should.eql(true);
+    });
+    r.end(true);
+    done();
+  });
+
   /** This test doesn't seem to work on node_redis
    it("should have function end() that emits event 'end'", function (done) {
 


### PR DESCRIPTION
Add a `.connected` property to match the actual RedisClient as seen here:
https://github.com/NodeRedis/node_redis/blob/04a09aa2ffcbae9f380b61a4afe15badfe5be5ef/index.js#L90
Default it to `false` until we emit `ready`, then set to `true`

 - Added tests to verify
 - npm version bump to 0.32.0