### PR TITLE
Fixed bpop family does not return key value array when list is non-empty

### DIFF
--- a/lib/list.js
+++ b/lib/list.js
@@ -158,8 +158,9 @@ var bpop = function (fn, mockInstance, keys, timeout, callback) {
   // Look if any element can be returned
   for (var i = 0; i < keys.length; i++) {
     if (mockInstance.storage[keys[i]] && mockInstance.storage[keys[i]].value.length > 0) {
-      val = fn.call(mockInstance.storage[keys[i]]);
-      mockInstance._callCallback(callback, null, val);
+      var key = keys[i];
+      val = fn.call(mockInstance.storage[key]);
+      mockInstance._callCallback(callback, null, [key, val]);
       return;
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-mock",
-  "version": "0.33.0",
+  "version": "0.37.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/test/redis-mock.list.test.js
+++ b/test/redis-mock.list.test.js
@@ -817,6 +817,34 @@ describe("blpop", function () {
       done();
     }, 1500);
   });
+
+  it("should not block when an element is already in the list", function(done) {
+    var r2 = helpers.createClient();
+    var time = false;
+
+    r2.rpush("foo11", "bar");
+    r.blpop("foo11", 1, function (err, result) {
+      result[0].should.equal("foo11");
+      result[1].should.equal("bar");
+      time.should.equal(false);
+      done();
+    });
+
+    setTimeout(function () {
+      time = true
+    }, 200);
+  });
+
+  it("should return an array of key followed by value when an element is already in the list", function(done) {
+    var r2 = helpers.createClient();
+
+    r2.rpush("foo11", "bar");
+    r.blpop("foo11", 1, function (err, result) {
+      result[0].should.equal("foo11");
+      result[1].should.equal("bar");
+      done();
+    });
+  });
 });
 
 describe("ltrim", function(argument) {


### PR DESCRIPTION
### Description:
When the list is non-empty, calling `blpop` and `brpop` calls the callback with only the value in the result

### Affected methods:

- `blpop`
- `brpop`

### Expected Behaviour:
The result in callback function should be `[key, value]`

### Actual Behaviour:
The resultt in callback function contains only the value

### Reference:
https://redis.io/commands/blpop#return-value