### PR TITLE
fixed: set nullPointer

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -36,7 +36,7 @@ var parseArguments = function(args, options) { // eslint-disable-line complexity
         // arg2 = callback
         arr = [args[0]];
         if(options && options.valueIsString) {
-           arr.push(args[1].toString());
+           arr.push(String(args[1]));
         } else if(options && options.valueIsBuffer) {
            arr.push(args[1]);
         } else {

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -42,6 +42,29 @@ describe("set", function () {
     });
   });
 
+  it("should set `null` as value", function(done) {
+    r.set("foo", null, function (err, result) {
+      result.should.equal("OK");
+      
+      r.get("foo", function(err, result) {
+        result.should.equal("null");
+        done();
+      });
+    });
+  });
+  
+
+  it("should set `undefined` as value", function(done) {
+    r.set("foo", undefined, function (err, result) {
+      result.should.equal("OK");
+      
+      r.get("foo", function(err, result) {
+        result.should.equal("undefined");
+        done();
+      });
+    });
+  });
+
   it("should allow buffers as second argument to the set function", function (done) {
     r.set("foo", new Buffer("bar"), function (err, result) {
       (err === null).should.be.true;


### PR DESCRIPTION
+ `redis-mock` is going to crash if calling `set('key', null)`
    - `(null || undefined).toString()` got a fatal error
    - `String(null || undefined)` is a good way to fix it

+ Error
```js
should set `null` as value:
     TypeError: Cannot read property 'toString' of null
      at parseArguments (/Users/danielssun/Projects/redis-mock/lib/redis-mock.js:39:29)
      at RedisClient.set.RedisClient.SET (/Users/danielssun/Projects/redis-mock/lib/redis-mock.js:353:16)
      at context.<anonymous> (/Users/danielssun/Projects/redis-mock/test/redis-mock.strings.test.js:47:7)
      at Test.Runnable.run (/Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runnable.js:233:15)
      at Runner.runTest (/Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:387:10)
      at /Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:470:12
      at next (/Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:312:14)
      at /Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:322:7
      at next (/Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:257:23)
      at Immediate._onImmediate (/Users/danielssun/Projects/redis-mock/node_modules/mocha/lib/runner.js:289:5)
      at runCallback (timers.js:810:20)
      at tryOnImmediate (timers.js:768:5)
      at processImmediate [as _immediateCallback] (timers.js:745:5)
```
