### PR TITLE
Add callback support for the publish command.

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -204,8 +204,14 @@ RedisClient.prototype.subscribe = pubsub.subscribe;
 RedisClient.prototype.psubscribe = pubsub.psubscribe;
 RedisClient.prototype.unsubscribe = pubsub.unsubscribe;
 RedisClient.prototype.punsubscribe = pubsub.punsubscribe;
-RedisClient.prototype.publish = function (channel, msg) {
+RedisClient.prototype.publish = function (channel, msg, callback) {
   pubsub.publish.call(this, MockInstance, channel, msg);
+
+  process.nextTick(function () {
+    if (callback) {
+      return callback();
+    }
+  });
 }
 
 /**


### PR DESCRIPTION
This is necessary when you promisify the publish in test codes.