### PR TITLE
Add files attributes for npm to reduce package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,9 @@
     "test": "make test",
     "lint": "eslint ./lib ./test"
   },
+  "files": [
+    "lib"
+  ],
   "keywords": [
     "redis",
     "redis-mock",


### PR DESCRIPTION
Add "files" attributes for npm to only pack necessary files.
This is can reduce package size a lot under `node_modules`.

see https://docs.npmjs.com/misc/developers