### PR TITLE
add support for arguments as array for sadd and srem methods

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -670,14 +670,12 @@ var getVarargs = function (args) {
   return {members: members, callback: callback};
 }
 
-RedisClient.prototype.sadd = RedisClient.prototype.SADD = function (key, member, callback) {
-  var args = getVarargs(arguments);
-  setfunctions.sadd.call(this, MockInstance, key, args.members, args.callback);
+RedisClient.prototype.sadd = RedisClient.prototype.SADD = function () {
+  setfunctions.sadd.apply(this, [MockInstance].concat(parseArguments(arguments)));
 }
 
-RedisClient.prototype.srem = RedisClient.prototype.SREM = function (key, member, callback) {
-  var args = getVarargs(arguments);
-  setfunctions.srem.call(this, MockInstance, key, args.members, args.callback);
+RedisClient.prototype.srem = RedisClient.prototype.SREM = function () {
+  setfunctions.srem.apply(this, [MockInstance].concat(parseArguments(arguments)));
 }
 
 RedisClient.prototype.smembers = RedisClient.prototype.SMEMBERS = function (key, callback) {

--- a/lib/set.js
+++ b/lib/set.js
@@ -4,7 +4,28 @@ var shuffle = require('./helpers.js').shuffle;
 /**
  * Sadd
  */
-exports.sadd = function (mockInstance, key, members, callback) {
+exports.sadd = function (mockInstance, key) {
+  // We require at least 3 arguments
+  // 0: mockInstance
+  // 1: set name
+  // 2: members to add
+  if (arguments.length <= 3) {
+    return;
+  }
+
+  var callback = null;
+  var membersToAdd = [];
+
+  for (var i = 2; i < arguments.length; i++) {
+    // Argument is not callback
+    if ('function' !== typeof arguments[i]) {
+      membersToAdd.push(arguments[i]);
+    } else {
+      callback = arguments[i];
+      break;
+    }
+  }
+
   if (mockInstance.storage[key] && mockInstance.storage[key].type !== 'set') {
     var err = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
     return mockInstance._callCallback(callback, err);
@@ -14,9 +35,9 @@ exports.sadd = function (mockInstance, key, members, callback) {
 
   var set = mockInstance.storage[key].value;
   var addCount = 0;
-  for (var i = 0; i < members.length; i++) {
-    if (set.indexOf(Item._stringify(members[i])) < 0) {
-      set.push(Item._stringify(members[i]));
+  for (var j = 0; j < membersToAdd.length; j++) {
+    if (set.indexOf(Item._stringify(membersToAdd[j])) < 0) {
+      set.push(Item._stringify(membersToAdd[j]));
       addCount++;
     }
   }
@@ -27,23 +48,43 @@ exports.sadd = function (mockInstance, key, members, callback) {
 /**
  * Srem
  */
-exports.srem = function (mockInstance, key, members, callback) {
+exports.srem = function (mockInstance, key) {
+  // We require at least 3 arguments
+  // 0: mockInstance
+  // 1: set name
+  // 2: members to remove
+  if (arguments.length <= 3) {
+    return;
+  }
+
+  var callback = null;
+  var membersToRemove = [];
+
+  for (var i = 2; i < arguments.length; i++) {
+    // Argument is not callback
+    if ('function' !== typeof arguments[i]) {
+      membersToRemove.push(arguments[i]);
+    } else {
+      callback = arguments[i];
+      break;
+    }
+  }
+
   var remCount = 0;
 
   if (mockInstance.storage[key]) {
-
     if (mockInstance.storage[key].type !== 'set') {
       var err = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
       return mockInstance._callCallback(callback, err);
+    }
 
-    } else {
-      var set = mockInstance.storage[key].value;
-      for (var i = 0; i < members.length; i++) {
-        for (var j = 0; j < set.length; j++) {
-          if (set[j] == Item._stringify(members[i])) {
-            set.splice(j, 1);
-            remCount++;
-          }
+    var set = mockInstance.storage[key].value;
+
+    for (var j = 0; j < membersToRemove.length; j++) {
+      for (var k = 0; k < set.length; k++) {
+        if (set[k] === Item._stringify(membersToRemove[j])) {
+          set.splice(k, 1);
+          remCount++;
         }
       }
     }
@@ -127,7 +168,7 @@ exports.smove = function (mockInstance, source, destination, member, callback) {
   }
 
   for (var j = 0; j < set.length; j++) {
-    if (set[j] == Item._stringify(member)) {
+    if (set[j] === Item._stringify(member)) {
       set.splice(j, 1);
     }
   }

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -73,6 +73,21 @@ describe('sadd', function () {
     });
   });
 
+  it('should support arguments as array', function (done) {
+    r.sadd('foo', ['bar', 'baz'], function (err, result) {
+      result.should.eql(2);
+
+      r.smembers('foo', function (err, result) {
+        result.should.be.instanceof(Array);
+        result.should.have.length(2);
+        result.should.containEql('bar');
+        result.should.containEql('baz');
+
+        done();
+      });
+    });
+  });
+
   it('should support arguments without callback', function (done) {
     r.sadd('foo', 'bar', 'baz');
     r.smembers('foo', function (err, result) {
@@ -155,6 +170,18 @@ describe('srem', function () {
 
       r.srem('foo', 'bar', function (err, result) {
         err.message.should.eql('WRONGTYPE Operation against a key holding the wrong kind of value');
+
+        done();
+      });
+    });
+  });
+
+  it('should support arguments as array', function (done) {
+    r.sadd('foo', 'bar', 'baz', function (err, result) {
+      r.srem('foo', ['bar', 'baz']);
+      r.smembers('foo', function (err, result) {
+        result.should.be.instanceof(Array);
+        result.should.have.length(0);
 
         done();
       });


### PR DESCRIPTION
PR for issue #83
Adds support for members to be passed as arrays instead of arguments.