### PR TITLE
Check that callback is actually a function before calling it

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -81,7 +81,7 @@ function RedisMock() {
    * on the next process tick
    */
   this._callCallback = function (callback, err, result) {
-    if (callback) {
+    if (callback && typeof callback === 'function') {
       process.nextTick(function () {
         callback(err, result);
       });


### PR DESCRIPTION
This PR solves an issue where the `callback` argument was an array and not a function. 

I haven't had time to investigate why the first argument to `_callCallback` was an array and not a function, however this fixes the issue for us in the short term. 

A clue is that we are using redis-mock as a mock for https://github.com/mmkal/handy-redis. I believe the issue lies in the fact that handy-redis works with promises and not callbacks. This means that the redis method calls will not have a final callback argument. 