### PR TITLE
Fix callback issue

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -414,14 +414,14 @@ RedisClient.prototype.set = RedisClient.prototype.SET = function (key, value, ca
             } else {
                 stringfunctions.set.call(this, MockInstance, key, value, function () {
                   keyfunctions.expire.call(this, MockInstance, key, expireTime, function(err, result) {
-                      callback(err, "OK");
+                      MockInstance._callCallback(callback, err, "OK");
                   });
                 });
             }
         } else {
             stringfunctions.set.call(this, MockInstance, key, value, function () {
               keyfunctions.expire.call(this, MockInstance, key, expireTime, function(err, result) {
-                  callback(err, "OK");
+                  MockInstance._callCallback(callback, err, "OK");
               });
             });
         }


### PR DESCRIPTION
When doing a promisified client.get, redis-mock fails with:

```
/node_modules/redis-mock/lib/redis-mock.js:424
                  callback(err, "OK");
                  ^

TypeError: callback is not a function
    at /node_modules/redis-mock/lib/redis-mock.js:424:19
    at /node_modules/redis-mock/lib/redis-mock.js:86:9
    at processTicksAndRejections (internal/process/next_tick.js:74:9)
```

Resolved by using the _callCallback wrapper to make sure the callback is actually a function