### PR TITLE
Added zrevrangebyscore to multi.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Currently implemented are the following redis commands:
 * zremrangebyrank
 * zremrangebyscore
 * zrevrange
+* zrevrangebyscore
 * zrevrank
 * zunionstore (Partial: no support for `WEIGHTS` or `AGGREGATE` yet)
 * zinterstore (Partial: no support for `WEIGHTS` or `AGGREGATE` yet)

--- a/lib/multi.js
+++ b/lib/multi.js
@@ -196,6 +196,7 @@ makeCommands([
   'zremrangebyrank',
   'zremrangebyscore',
   'zrevrange',
+  'zrevrangebyscore',
   'zrevrank',
   'zscore'
 ]);


### PR DESCRIPTION
`zrevrangebyscore` is inaccesible from the mock class. Added to multi to allow usage.