### PR TITLE
Replicated error behavior between node_redis, and redis_mock

### DIFF
--- a/lib/hash.js
+++ b/lib/hash.js
@@ -339,6 +339,15 @@ exports.hmget = function (mockInstance) {
   // 1: hash name
   // 2: key/value object or first key name
   if (arguments.length <= 3) {
+
+    if ('function' === typeof arguments[arguments.length - 1]) {
+      mockInstance._callCallback(
+        arguments[arguments.length - 1],
+        new Error("ERR wrong number of arguments for 'hmget' command"),
+        keyValues
+      );
+    }
+
     return;
   }
 

--- a/test/redis-mock.hash.test.js
+++ b/test/redis-mock.hash.test.js
@@ -567,6 +567,15 @@ describe("multiple get/set", function () {
     });
   });
 
+  it("should produce the correct error if called with an empty of keys", function(done) {
+    r.hmget(mHash2, [], function(err, result) {
+      should.not.exist(result);
+      err.message.should.equal("ERR wrong number of arguments for 'hmget' command");
+
+      done();
+    });
+  });
+
   //HKEYS
   it("should be able to get all keys for hash", function (done) {
 


### PR DESCRIPTION
Passing an empty array for the keys should produce an error to replicate node_redis behavior.
Currently, it just doesn't call the supplied callback, which causes code to hang.