### PR TITLE
ensure all commands are run in multi()

### DIFF
--- a/lib/multi.js
+++ b/lib/multi.js
@@ -93,10 +93,12 @@ Multi.prototype.exec = Multi.prototype.exec_atomic = function(callback) {
       this._MockInterface._callCallback(callback, err);
     }
   } else {
-    if (this._commands.length == 0) {
+    if (this._commands.length === 0) {
       this._MockInterface._callCallback(callback, null, []);
     } else {
-      this._commands[0]();
+      this._commands.forEach(function(c) {
+        c()
+      });
     }
   }
   return this;

--- a/test/redis-mock.multi.test.js
+++ b/test/redis-mock.multi.test.js
@@ -54,6 +54,16 @@ describe("multi()", function () {
       });
     });
 
+    it("exec() should execute callback", function (done) {
+      r.multi().
+        incr('foo1').
+        incrby('foo2', 2).
+        exec(function (err, results) {
+          should.deepEqual(results, [1,2]);
+          done();
+        });
+    });
+
     it("should handle an array of commands", function (done) {
       r.set('foo', 3, function () {
         r.multi([


### PR DESCRIPTION
I'm seeing a bug where if you specify more than 1 command when using `.multi()`, only the first one is executed. I've tracked down the problem and I've implemented the fix which passes the unit test. 

However, this seems to have broken sorted sets in redis-mock. The following tests are failing:

```
  batch()
    exec()
      1) should run sorted set operations in order

      "Uncaught AssertionError: expected Array [ 1, 0 ] deepEqual Array [ 1, 1 ]"

  multi()
    exec()
      2) should run sorted set operations in order

      "Uncaught AssertionError: expected Array [ 1, 0 ] deepEqual Array [ 1, 1 ]"

  sortedset multi commands
    3) should handle multi exec 

    "Error: done() called multiple times"
```

Could someone help me debug why this is causing them to fail? For what it's worth, all tests pass when running `make check-tests`.