### PR TITLE
set() method: Support ttl argument specified as string

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -404,8 +404,8 @@ RedisClient.prototype.set = RedisClient.prototype.SET = function (key, value, ca
                 isNx = true;
             } else if(typeof args[i] === 'string' && args[i].toLowerCase() === "xx") {
                 isXx = true;
-            } else if(typeof args[i] === 'number' && args[i] % 1 === 0 ) {
-                expireTime = args[i];
+            } else if(!isNaN(parseInt(args[i]))) {
+                expireTime = parseInt(args[i]);
             }
         }
     }

--- a/test/redis-mock.strings.test.js
+++ b/test/redis-mock.strings.test.js
@@ -104,6 +104,28 @@ describe("set", function () {
     });
   });
 
+  it("should accept the tll argument as a string", function (done) {
+
+    r.set("foo", "bar", 'EX', '10', function (err, result) {
+      result.should.equal("OK");
+
+          r.get("foo", function (err, result) {
+
+            result.should.equal("bar");
+
+            // done();
+            r.ttl("foo", function (err, result) {
+              
+              result.should.not.equal(-1)
+
+              done()
+
+            });
+
+          });
+    });
+  });
+
   it("should call toString() on non-buffer, non-string values", function (done) {
 
     r.set("foo", {probably_not:'desired'}, function (err, result) {


### PR DESCRIPTION
The real node-redis client supports the ttl argument as string:
```javascript
const client = createClient()
client.set("foo", "bar", "EX", "10")
```

The mock client doesn't.

Fixed this and added a test case for it.