### PR TITLE
Add a ready property and tests

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -116,6 +116,7 @@ function RedisClient(stream, options) {
   var self = this;
 
   this.connected = false;
+  this.ready = false;
   this.pub_sub_mode = false;
 
 
@@ -145,6 +146,7 @@ function RedisClient(stream, options) {
 
   process.nextTick(function () {
     self.connected = true;
+    self.ready = true;
     self.emit("connect");
     self.emit("ready");
   });
@@ -181,6 +183,7 @@ RedisClient.prototype.quit = function (callback) {
   this.subscriptions = {};
 
   this.connected = false;
+  this.ready = false;
 
   //Remove listener from MockInstance to avoid 'too many subscribers errors'
   MockInstance.removeListener('message', this._message);

--- a/test/redis-mock.test.js
+++ b/test/redis-mock.test.js
@@ -135,6 +135,37 @@ describe("redis-mock", function () {
 
   });
 
+  it("should have '.ready' boolean property that reflects 'ready' state", function (done) {
+
+    var r = redismock.createClient();
+
+    r.ready.should.be.an.instanceof(Boolean);
+    r.ready.should.eql(false);
+    r.on("ready", function () {
+      r.ready.should.eql(true);
+    });
+    r.quit(done);
+  });
+
+
+  it("should not be ready after end() is called", function (done) {
+
+    var r = redismock.createClient();
+
+    r.on("ready", function () {
+      r.ready.should.eql(true);
+
+      r.quit(function (err) {
+        if (err) {
+          should.fail(err, null, "Expected null error.", "");
+        }
+        r.ready.should.eql(false);
+        done();
+      });
+    });
+
+  });
+
   it("should have function end() that emits event 'end'", function (done) {
 
     var r = redismock.createClient();


### PR DESCRIPTION
- Added a `ready` property to match the actual RedisClient (https://github.com/NodeRedis/node-redis/blob/master/index.js#L371). `false` by default, `true` when `ready` is sent.
- Added two tests.

Similar to https://github.com/yeahoffline/redis-mock/pull/92.