### PR TITLE
Update redis-mock.js

### DIFF
--- a/lib/redis-mock.js
+++ b/lib/redis-mock.js
@@ -127,8 +127,9 @@ function RedisClient(stream, options) {
     if (ch in self.subscriptions && self.subscriptions[ch] == true) {
       self.emit('message', ch, msg);
     }
-
-    Object.keys(self.psubscriptions).some(function(key) {
+    
+    // Emit the message to ALL matching subscriptions
+    Object.keys(self.psubscriptions).forEach(function(key) {
       if(self.psubscriptions[key].test(ch)) {
         self.emit('pmessage', key, ch, msg);
         return true;


### PR DESCRIPTION
If one is using redis PubSub with wildcards and namespaces for more complex and generic events
to listen to changes on specific clients, models, etc. e.g. subscribers like "client_1:modelX:*" or "*:modelX:write" (and so on), the "pmessage" needs to be emitted to ALL matching subscribers, not only the first one.

In your test cases there is always only one matching subscriber pattern, so everything works fine.

The "some" function on the psubscriptions stops at the first matching reg expression. All following matching subscribers are ignored.

So I changed the array function to "forEach" to emit the message to every matching subscriber pattern.
The only drawback with this solution is the loop over each element of the subscriber array.

Nice work by the way :)



