### PR TITLE
Make smembers result copy

### DIFF
--- a/lib/set.js
+++ b/lib/set.js
@@ -104,7 +104,7 @@ exports.smembers = function (mockInstance, key, callback) {
       var err = new Error('WRONGTYPE Operation against a key holding the wrong kind of value');
       return mockInstance._callCallback(callback, err);
     } else {
-      members = mockInstance.storage[key].value;
+      members = mockInstance.storage[key].value.slice(0);
     }
   }
 

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -254,7 +254,7 @@ describe('smembers', function () {
       });
     });
   });
-  it('should not mutate retrieved array of members with srem', function (done) {
+  it('should return a copy and not a mutable reference', function (done) {
     r.sadd('foo', 'bar', function () {
       r.smembers('foo', function (err, membersBeforeRemoval) {
         r.srem('foo', 'bar', function (err, result) {

--- a/test/redis-mock.set.test.js
+++ b/test/redis-mock.set.test.js
@@ -254,6 +254,18 @@ describe('smembers', function () {
       });
     });
   });
+  it('should not mutate retrieved array of members with srem', function (done) {
+    r.sadd('foo', 'bar', function () {
+      r.smembers('foo', function (err, membersBeforeRemoval) {
+        r.srem('foo', 'bar', function (err, result) {
+          membersBeforeRemoval.should.be.instanceof(Array);
+          membersBeforeRemoval.should.have.length(1);
+          result.should.eql(1);
+          return done();
+        });
+      });
+    });
+  });
 });
 
 describe('scard', function () {


### PR DESCRIPTION
this fix should slice the array copy for set > smembers result instead of returning a reference to the set.value. It prevents bugs when you iterate over the set. Removing or adding items in sequence and the underlying array changing causes for the iterator to obtain incorrect current index or array length.