### PR TITLE
Adding the travis configuration to ensure test execution on Node 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "6"
   - "7"
   - "8"
   - "9"


### PR DESCRIPTION
as the actual redis library supports Node 6, redis-mock should stay compatible back to Node 6 as well. Adding the travis configuration to ensure test execution on Node 6