### PR TITLE
Add callback to pubsub methods

### DIFF
--- a/lib/client/pubsub.js
+++ b/lib/client/pubsub.js
@@ -31,6 +31,13 @@ exports.subscribe = function () {
       });
     }
   }
+  if ('function' === typeof arguments[arguments.length - 1]) {
+    var callback = arguments[arguments.length - 1];
+    var channels = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
+    process.nextTick(function () {
+      callback(null, ...channels);
+    });
+  }
 };
 
 /**
@@ -52,6 +59,13 @@ exports.psubscribe = function () {
         self.emit('psubscribe', channelName);
       });
     }
+  }
+  if ('function' === typeof arguments[arguments.length - 1]) {
+    var callback = arguments[arguments.length - 1];
+    var channels = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
+    process.nextTick(function () {
+      callback(null, ...channels);
+    });
   }
 };
 /**
@@ -83,7 +97,13 @@ exports.unsubscribe = function () {
       })(channelName));
     }
   }
-
+  if ('function' === typeof arguments[arguments.length - 1]) {
+    var callback = arguments[arguments.length - 1];
+    var channels = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
+    process.nextTick(function () {
+      callback(null, ...channels);
+    });
+  }
   // TODO: If this was the last subscription, pub_sub_mode should be set to false
   this.pub_sub_mode = false;
 };
@@ -110,6 +130,13 @@ exports.punsubscribe = function () {
         self.emit('punsubscribe', channelName);
       });
     }
+  }
+  if ('function' === typeof arguments[arguments.length - 1]) {
+    var callback = arguments[arguments.length - 1];
+    var channels = Array.prototype.slice.call(arguments, 0, arguments.length - 1);
+    process.nextTick(function () {
+      callback(null, ...channels);
+    });
   }
   // TODO: If this was the last subscription, pub_sub_mode should be set to false
 };

--- a/test/client/redis-mock.pubsub.test.js
+++ b/test/client/redis-mock.pubsub.test.js
@@ -27,7 +27,10 @@ describe("publish and subscribe", function () {
 
     });
 
-    r.subscribe(channelName);
+    r.subscribe(channelName, function (err, ch) {
+      should.equal(err, null);
+      should.equal(ch, channelName);
+    });
   });
 
   it("should unsubscribe to all channels if no arguments are given", function (done) {
@@ -56,8 +59,14 @@ describe("publish and subscribe", function () {
       }
     });
 
-    r.subscribe(channelNames[0]);
-    r.subscribe(channelNames[1]);
+    r.subscribe(channelNames[0], function (err, ch) {
+      should.equal(err, null);
+      should.equal(channelNames[0], channelNames[0]);
+    });
+    r.subscribe(channelNames[1], function (err, ch) {
+      should.equal(err, null);
+      should.equal(ch, channelNames[1]);
+    });
   });
 
   it("should psubscribe and punsubscribe to a channel", function (done) {
@@ -76,7 +85,10 @@ describe("publish and subscribe", function () {
       should.equal(ch, channelName);
       r.quit(done);
     });
-    r.psubscribe(channelName);
+    r.psubscribe(channelName, function (err, ch) {
+      should.equal(err, null);
+      should.equal(ch, channelName);
+    });
   });
 
   it("suscribing and publishing with the same connection should make an error", function (done) {


### PR DESCRIPTION
This PR adds the option for passing a callback as latest argument to pubsub methods as per #122 and the tests for the changes