### PR TITLE
Support sadd with 2 params #141

### DIFF
--- a/lib/server/set.js
+++ b/lib/server/set.js
@@ -8,7 +8,7 @@ exports.sadd = function (key) {
   // We require at least 3 arguments
   // 0: set name
   // 1: members to add
-  if (arguments.length <= 2) {
+  if (arguments.length < 2) {
     return;
   }
 


### PR DESCRIPTION
https://github.com/yeahoffline/redis-mock/issues/185

Fix sadd when being called with a single member. Example code:

```
mockRedis = require("redis-mock").createClient();
mockRedis.sadd("setName", "member");
```

Since only two arguments are passed, the check on line 11 resolves to true, so the method immediately exits without adding the member to the set.