### PR TITLE
fix: ensure exists works with array of values

### DIFF
--- a/lib/client/redis-client.js
+++ b/lib/client/redis-client.js
@@ -230,7 +230,11 @@ const getKeysVarArgs = function (args) {
   var keys = [];
   var hasCallback = typeof(args[args.length - 1]) === 'function';
   for (var i = 0; i < (hasCallback ? args.length - 1 : args.length); i++) {
-    keys.push(args[i]);
+    if (Array.isArray(args[i])) {
+      keys = keys.concat(args[i]);
+    } else {
+      keys.push(args[i]);
+    }
   }
   var callback = hasCallback ? args[args.length - 1] : undefined;
   return {keys: keys, callback: callback};

--- a/test/client/redis-mock.keys.test.js
+++ b/test/client/redis-mock.keys.test.js
@@ -82,10 +82,21 @@ describe("exists", function () {
 
   });
 
-  it("should return an array for multiple existing keys, existing and not", function (done) {
+  it("should return the correct amount of existing keys if passed as multiple args", function (done) {
     r.set("test", "test", function (err, result) {
       r.set("test2", "test", function (err, result) {
         r.exists("test", "test2", "nonexistant", function (err, result) {
+            result.should.eql(2);
+            done();
+        });
+      });
+    });
+  });
+
+  it("should return the correct amount of existing keys if passed as an array arg", function (done) {
+    r.set("test", "test", function (err, result) {
+      r.set("test2", "test", function (err, result) {
+        r.exists(["test", "test2", "nonexistant"], function (err, result) {
             result.should.eql(2);
             done();
         });


### PR DESCRIPTION
## Overview
When working with this lib I noticed that the `exist` method was double-wrapping an array of keys due to the way `getKeysVarArgs` was merging args. This adds a fix and test case to ensure users can use all of the following invocations:

```js
client.exists('key', cb)
client.exists('key', 'key2', cb)
client.exists(['key', 'key2'], cb)
```