### PR TITLE
Fix SET to work with NX flag does as expected

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ redis-mock
 
 ![Build status](https://github.com/yeahoffline/redis-mock/workflows/Build/badge.svg?branch=master)
 ![node-current](https://img.shields.io/node/v/redis-mock)
-![mock-completeness](https://img.shields.io/badge/Methods%20mocked-46%25%20(222%2F482)-red)
+![mock-completeness](https://img.shields.io/badge/Methods%20mocked-46%25%20(224%2F482)-red)
 [![GitHub issues](https://img.shields.io/github/issues/yeahoffline/redis-mock)](https://github.com/yeahoffline/redis-mock/issues)
 
 The goal of the `redis-mock` project is to create a feature-complete mock of [node_redis](https://github.com/NodeRedis/node_redis), which may be used interchangeably when writing unit tests for code that depends on `redis`.

--- a/lib/server/strings.js
+++ b/lib/server/strings.js
@@ -34,17 +34,20 @@ exports.set = function (key, value, callback, args = {}) {
   const keyExists = key in this.storage;
   const expirationTime = getExpirationTime();
 
+  let response = 'OK';
   if ((keyExists && args.xx) || (!keyExists && args.nx) || (!args.xx && !args.nx)) {
     // it it's okay to set the value
     this.storage[key] = createItem(value);
+  } else if (args.xx || args.nx) {
+    response = null;
   }
 
   if (expirationTime) {
     this.expire(key, expirationTime, (err, result) => {
-      helpers.callCallback(callback, err, "OK");
+      helpers.callCallback(callback, err, response);
     });
   } else {
-    helpers.callCallback(callback, null, "OK");
+    helpers.callCallback(callback, null, response);
   }
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "redis-mock",
-  "version": "0.56.3",
+  "version": "0.56.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.56.3",
+      "version": "0.56.4",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^5.16.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redis-mock",
-  "version": "0.56.3",
+  "version": "0.56.4",
   "description": "Redis client mock object for unit testing",
   "author": "Kristian Faeldt <kristian.faeldt@gmail.com>",
   "main": "./lib/index",


### PR DESCRIPTION
On real Redis we will get "OK" on the first call and null on the second, which is expected as the value was set at the first time and cannot be overwritten. Redis-mock will respond with "OK" on the first call, second and any other afterward which is not correct behavior. This will fix it to respond correctly.

Fix: https://github.com/yeahoffline/redis-mock/issues/198