### PR TITLE
Remove double `getUrl` that would never work

### DIFF
--- a/lib/utils/redis-mock-factory.js
+++ b/lib/utils/redis-mock-factory.js
@@ -7,7 +7,7 @@ let knownRedisHosts = {};
 const getUrl = (opts) => opts.host + ':' + opts.port + (opts.path || '');
 
 module.exports.getRedisMock = (createClientOptions) => {
-  const url = getUrl(getUrl(createClientOptions));
+  const url = getUrl(createClientOptions);
 
   if (!knownRedisHosts[url]) {
     knownRedisHosts[url] = new RedisMock();


### PR DESCRIPTION
Fixes #203. No tests added currently, but everything should still work.